### PR TITLE
awx: fix wrong state name

### DIFF
--- a/playbooks/awx-bootstrap.yml
+++ b/playbooks/awx-bootstrap.yml
@@ -94,7 +94,7 @@
       - configuration
 
     states:
-      - status-bootstrap
+      - bootstrap
 
     generic_roles:
       - auditd


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>