### PR TITLE
Use import_playbook

### DIFF
--- a/playbooks/awx-bootstrap.yml
+++ b/playbooks/awx-bootstrap.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for AWX API
-  include: awx-wait.yml
+  import_playbook: awx-wait.yml
 
 - hosts: localhost
   connection: local
@@ -44,7 +44,7 @@
         update_on_launch: false
 
 - name: Create smart inventories
-  include: awx-smart-inventories.yml
+  import_playbook: awx-smart-inventories.yml
 
 - hosts: localhost
   connection: local
@@ -794,7 +794,7 @@
         forks: "{{ forks }}"
 
 - name: Create workflows
-  include: awx-workflows.yml
+  import_playbook: awx-workflows.yml
 
 - name: Create schedules
-  include: awx-schedules.yml
+  import_playbook: awx-schedules.yml

--- a/playbooks/awx-disable-unreachable-hosts.yml
+++ b/playbooks/awx-disable-unreachable-hosts.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for AWX API
-  include: awx-wait.yml
+  import_playbook: awx-wait.yml
 
 - hosts: all
   gather_facts: false

--- a/playbooks/awx-schedules.yml
+++ b/playbooks/awx-schedules.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for AWX API
-  include: awx-wait.yml
+  import_playbook: awx-wait.yml
 
 - hosts: localhost
   connection: local

--- a/playbooks/awx-smart-inventories.yml
+++ b/playbooks/awx-smart-inventories.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for AWX API
-  include: awx-wait.yml
+  import_playbook: awx-wait.yml
 
 - hosts: localhost
   connection: local

--- a/playbooks/awx-workflows.yml
+++ b/playbooks/awx-workflows.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait for AWX API
-  include: awx-wait.yml
+  import_playbook: awx-wait.yml
 
 - hosts: localhost
   connection: local


### PR DESCRIPTION
[DEPRECATION WARNING]: 'include' for playbook includes. You should
use 'import_playbook' instead. This feature will be removed from
ansible-base in version 2.12.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>