### PR TITLE
Deprecate the generic-configuration playbook

### DIFF
--- a/playbooks/generic-configuration.yml
+++ b/playbooks/generic-configuration.yml
@@ -2,8 +2,11 @@
 - name: Update configuration
   hosts: "{{ hosts_manager|default('manager') }}"
 
-  collections:
-    - osism.commons
-
-  roles:
-    - role: configuration
+  tasks:
+    - name: Playbook was deprecated
+      fail:
+        msg: |
+          Playbook was deprecated. From now on, please use the playbook
+          of the same name in the manager environment. All configuration
+          parameters from environments/configuration.yml should be moved
+          to environments/manager/configuration.yml.


### PR DESCRIPTION
The manager-configuration playbook must be used now.

Signed-off-by: Christian Berendt <berendt@osism.tech>