### PR TITLE
Add all available debops collections to the grub playbook

### DIFF
--- a/playbooks/generic-grub.yml
+++ b/playbooks/generic-grub.yml
@@ -6,7 +6,10 @@
   become: true
 
   collections:
+    - debops.debops
+    - debops.roles01
     - debops.roles02
+    - debops.roles03
 
   roles:
     - role: grub


### PR DESCRIPTION
In this way, we are independent of shifts within the
collections of debops. This is also the way it is handled
in the examples of debops itself.

Closes osism/issues#127

Signed-off-by: Christian Berendt <berendt@osism.tech>