### PR TITLE
Remove manager-manager playbook

### DIFF
--- a/playbooks/manager-manager.yml
+++ b/playbooks/manager-manager.yml
@@ -1,6 +1,0 @@
----
-- name: Apply role osism.manager
-  hosts: manager
-
-  roles:
-  - role: osism.manager


### PR DESCRIPTION
The playbook is no longer needed since the
osism-update-manager command is available for it.

Signed-off-by: Christian Berendt <berendt@osism.tech>