### PR TITLE
Add manager-copy-ceph-keys playbook

### DIFF
--- a/playbooks/manager-copy-ceph-keys.yml
+++ b/playbooks/manager-copy-ceph-keys.yml
@@ -1,0 +1,39 @@
+---
+- name: Copy ceph keys to the configuration repository
+  hosts: manager
+
+  vars:
+    ceph_keys:
+      - src: ceph.client.admin.keyring
+        dest: "{{ configuration_directory }}/environments/infrastructure/files/ceph/ceph.client.admin.keyring"
+
+      - src: ceph.client.cinder.keyring
+        dest: "{{ configuration_directory }}/environments/kolla/files/overlays/cinder/cinder-volume/ceph.client.cinder.keyring"
+
+      - src: ceph.client.cinder.keyring
+        dest: "{{ configuration_directory }}/environments/kolla/files/overlays/cinder/cinder-backup/ceph.client.cinder.keyring"
+
+      - src: ceph.client.cinder-backup.keyring
+        dest: "{{ configuration_directory }}/environments/kolla/files/overlays/cinder/cinder-backup/ceph.client.cinder-backup.keyring"
+
+      - src: ceph.client.cinder.keyring
+        dest: "{{ configuration_directory }}/environments/kolla/files/overlays/nova/ceph.client.cinder.keyring"
+
+      - src: ceph.client.nova.keyring
+        dest: "{{ configuration_directory }}/environments/kolla/files/overlays/nova/ceph.client.nova.keyring"
+
+      - src: ceph.client.glance.keyring
+        dest: "{{ configuration_directory }}/environments/kolla/files/overlays/glance/ceph.client.glance.keyring"
+
+      - src: ceph.client.gnocchi.keyring
+        dest: "{{ configuration_directory }}/environments/kolla/files/overlays/gnocchi/ceph.client.gnocchi.keyring"
+
+  tasks:
+    - name: Fetch ceph keys from the first monitor node
+      command: "osism apply ceph-fetch-keys"  # noqa 301
+      environment:
+        INTERACTIVE: false
+
+    - name: Copy ceph keys to the configuration repository
+      command: "docker cp manager_ceph-ansible_1:/share/{{ ceph_cluster_fsid }}/etc/ceph/{{ item.src }} {{ item.dest }}"  # noqa 301
+      loop: "{{ ceph_keys }}"


### PR DESCRIPTION
With this playbook the Ceph keys can be copied from
the /share directory of the ceph-ansible runtime
environment into the configuration repository.

Signed-off-by: Christian Berendt <berendt@osism.tech>