### PR TITLE
Add the clevis playbook

### DIFF
--- a/playbooks/infrastructure/clevis.yml
+++ b/playbooks/infrastructure/clevis.yml
@@ -1,0 +1,10 @@
+---
+- name: Apply role clevis
+  hosts: "{{ hosts_clevis|default('clevis') }}"
+  serial: "{{ osism_serial['clevis']|default(osism_serial_default)|default(0) }}"
+
+  collections:
+    - osism.commons
+
+  roles:
+    - role: clevis


### PR DESCRIPTION
This playbook will install the clevis role which is required
by network bound disk encryption as client part

Signed-off-by: Mathias Fechner <fechner@osism.tech>