### PR TITLE
Workaround for skipping hardening role

### DIFF
--- a/playbooks/generic/bootstrap.yml
+++ b/playbooks/generic/bootstrap.yml
@@ -32,7 +32,7 @@
       when:
         - (play_hosts | length) != (groups['all'] | length)
 
-- name: Apply bootstrap roles
+- name: Apply bootstrap roles part 1
   ignore_unreachable: true
   hosts: state_bootstrap_False
   serial: "{{ osism_serial_default|default(0) }}"
@@ -63,9 +63,29 @@
     - role: docker
     - role: facts
     - role: chrony
-    - role: hardening
-      become: true
+
+- name: Apply bootstrap role part 2
+  ignore_unreachable: true
+  hosts: state_bootstrap_False
+  serial: "{{ osism_serial_default|default(0) }}"
+  strategy: "{{ osism_strategy|default('free') }}"
+
+  tasks:
+    - name: Include hardening role
+      ansible.builtin.include_role:
+        name: hardening
       when: enable_hardening|default('true')|bool
+
+- name: Apply bootstrap roles part 3
+  ignore_unreachable: true
+  hosts: state_bootstrap_False
+  serial: "{{ osism_serial_default|default(0) }}"
+  strategy: "{{ osism_strategy|default('free') }}"
+
+  collections:
+    - osism.services
+
+  roles:
     - role: auditd
     - role: journald
 


### PR DESCRIPTION
With the `when` condition attached to the role directly, all tasks from
the role are still executed, but skipped. This leads to an error in this
special, because of some loop variable expansion failing. Work around
this by using a conditional include_role task.

Closes: osism/testbed#1254
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>