### PR TITLE
Drop hddtemp role from bootstrap playbook

### DIFF
--- a/playbooks/generic/bootstrap.yml
+++ b/playbooks/generic/bootstrap.yml
@@ -55,7 +55,6 @@
     - role: sysctl
     - role: services
     - role: motd
-    - role: hddtemp
     - role: rng
     - role: smartd
     - role: cleanup


### PR DESCRIPTION
The hddtemp role is deprecated and does no longer work for Ubuntu 22.04.
Drop it from bootstrap until we have a better solution.

Related: https://github.com/osism/ansible-collection-services/issues/822
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>