### PR TITLE
ansible-lint: only warn about experimental rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -19,3 +19,5 @@ skip_list:
   - schema
   - yaml
   - fqcn-builtins
+warn_list:
+  - experimental  # all rules tagged as experimental


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>