### PR TITLE
Ansible-lint: Add Ceph playbook to the tests

### DIFF
--- a/.github/workflows/check-ansible-syntax.yml
+++ b/.github/workflows/check-ansible-syntax.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: ansible/ansible-lint-action@main
       - uses: ansible/ansible-lint-action@main
         with:
+          path: playbooks/ceph
+      - uses: ansible/ansible-lint-action@main
+        with:
           path: playbooks/generic
       - uses: ansible/ansible-lint-action@main
         with:


### PR DESCRIPTION
In this repository ansible-lint can´t find all playbooks
because of the structure of the repository. So we need to
add the playbooks in the GitHub Actions.

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
