### PR TITLE
Add enable_resolvconf argument

### DIFF
--- a/playbooks/generic/bootstrap.yml
+++ b/playbooks/generic/bootstrap.yml
@@ -47,6 +47,7 @@
     - role: hosts
     - role: proxy
     - role: resolvconf
+      when: enable_resolvconf | default('true') | bool
     - role: repository
     - role: rsyslog
     - role: systohc

--- a/playbooks/generic/maintenance.yml
+++ b/playbooks/generic/maintenance.yml
@@ -66,6 +66,7 @@
     - role: hosts
     - role: proxy
     - role: resolvconf
+      when: enable_resolvconf | default('true') | bool
     - role: repository
     - role: rsyslog
     - role: systohc

--- a/playbooks/generic/resolvconf.yml
+++ b/playbooks/generic/resolvconf.yml
@@ -9,3 +9,4 @@
 
   roles:
     - role: resolvconf
+      when: enable_resolvconf | default('true') | bool


### PR DESCRIPTION
This makes it possible to skip the resolvconf role, e.g. to configure the name servers via the network.

Signed-off-by: Christian Berendt <berendt@osism.tech>