### PR TITLE
Set changed_when=False for group_by tasks

### DIFF
--- a/playbooks/generic/auditd.yml
+++ b/playbooks/generic/auditd.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_auditd_{{ enable_auditd | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role auditd
   hosts:

--- a/playbooks/generic/bootstrap.yml
+++ b/playbooks/generic/bootstrap.yml
@@ -7,6 +7,7 @@
     - name: Group hosts based on state bootstrap
       ansible.builtin.group_by:
         key: state_bootstrap_{{ ansible_local.osism.bootstrap.status | default("False") | bool }}
+      changed_when: false
 
 - name: Gather facts for all hosts
   ignore_unreachable: true

--- a/playbooks/generic/chrony.yml
+++ b/playbooks/generic/chrony.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_chrony_{{ enable_chrony | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role chrony
   hosts:

--- a/playbooks/generic/configfs.yml
+++ b/playbooks/generic/configfs.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_configfs_{{ enable_configfs | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role configfs
   hosts:

--- a/playbooks/generic/containerd.yml
+++ b/playbooks/generic/containerd.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_containerd_{{ enable_containerd | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role containerd
   hosts:

--- a/playbooks/generic/docker-compose.yml
+++ b/playbooks/generic/docker-compose.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_docker_{{ enable_docker | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role docker_compose
   hosts:

--- a/playbooks/generic/docker-login.yml
+++ b/playbooks/generic/docker-login.yml
@@ -11,6 +11,7 @@
         - enable_docker_{{ enable_docker | default('true') | bool }}
         - enable_docker_login_{{ enable_docker_login | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role docker_login
   hosts:

--- a/playbooks/generic/docker.yml
+++ b/playbooks/generic/docker.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_docker_{{ enable_docker | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role docker
   hosts:

--- a/playbooks/generic/frr.yml
+++ b/playbooks/generic/frr.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_frr_{{ enable_frr | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role frr
   hosts:

--- a/playbooks/generic/lldpd.yml
+++ b/playbooks/generic/lldpd.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_lldpd_{{ enable_lldpd | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role lldpd
   hosts:

--- a/playbooks/generic/lynis.yml
+++ b/playbooks/generic/lynis.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_lynis_{{ enable_lynis | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role lynis
   hosts:

--- a/playbooks/generic/maintenance.yml
+++ b/playbooks/generic/maintenance.yml
@@ -7,10 +7,12 @@
     - name: Group hosts based on state bootstrap
       ansible.builtin.group_by:
         key: state_bootstrap_{{ ansible_local.osism.bootstrap.status | default("False") | bool }}
+      changed_when: false
 
     - name: Group hosts based on state maintenance
       ansible.builtin.group_by:
         key: state_maintenance_{{ ansible_local.osism.maintenance.status | default("False") | bool }}
+      changed_when: false
 
 - name: Group hosts based on reachability
   ignore_unreachable: true

--- a/playbooks/generic/patchman-client.yml
+++ b/playbooks/generic/patchman-client.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_patchman_client_{{ enable_patchman_client | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role patchman_client
   hosts:

--- a/playbooks/generic/remove-cockpit.yml
+++ b/playbooks/generic/remove-cockpit.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_cockpit_{{ enable_cockpit | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Remove cockpit
   hosts:

--- a/playbooks/generic/runc.yml
+++ b/playbooks/generic/runc.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_runc_{{ enable_runc | default('true') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role runc
   hosts:

--- a/playbooks/generic/trivy.yml
+++ b/playbooks/generic/trivy.yml
@@ -10,6 +10,7 @@
       with_items:
         - enable_trivy_{{ enable_trivy | default('false') | bool }}
       tags: always
+      changed_when: false
 
 - name: Apply role trivy
   hosts:


### PR DESCRIPTION
The tasks do not change anything on the target host and always change. Regardless of whether changes really take place. Therefore changed_when is set to False here.

Signed-off-by: Christian Berendt <berendt@osism.tech>