### PR TITLE
ansible-lint: do not check galaxy[no-changelog] rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,9 +15,10 @@ use_default_rules: true
 rulesdir:
   - ./.ansible-lint-rules/
 skip_list:
+  - fqcn-builtins
+  - galaxy[no-changelog]
   - ignore-errors
   - schema
   - yaml
-  - fqcn-builtins
 warn_list:
   - experimental  # all rules tagged as experimental


### PR DESCRIPTION
We currently manage our changelogs via osism/release.

Signed-off-by: Christian Berendt <berendt@osism.tech>