### PR TITLE
Add docker_compose to the bootstrap & maintenance playbooks

### DIFF
--- a/playbooks/generic/bootstrap.yml
+++ b/playbooks/generic/bootstrap.yml
@@ -64,6 +64,7 @@
     - role: cleanup
     - role: timezone
     - role: docker
+    - role: docker_compose
     - role: facts
     - role: chrony
     - role: lldpd

--- a/playbooks/generic/maintenance.yml
+++ b/playbooks/generic/maintenance.yml
@@ -84,6 +84,7 @@
     - role: cleanup
     - role: timezone
     - role: docker
+    - role: docker_compose
     - role: facts
     - role: chrony
     - role: lldpd


### PR DESCRIPTION
We need docker_compose for various helper services on all systems.

Signed-off-by: Christian Berendt <berendt@osism.tech>