### PR TITLE
Set osds_per_device = 1 if osds_per_device is not set

### DIFF
--- a/playbooks/ceph/validate-ceph-osds.yml
+++ b/playbooks/ceph/validate-ceph-osds.yml
@@ -74,7 +74,7 @@
         _osds_count_total: 0
         _osds_count_by_host: 0
         _osds_num_per_device:
-          "{{ _osds_configuration_vars['osds_per_device'] }}"
+          "{{ _osds_configuration_vars['osds_per_device']|default(1) }}"
         _osds_dmcrypt:
           "{{ _osds_configuration_vars['dmcrypt'] }}"
         _osds_container_test_data: []


### PR DESCRIPTION
osds_per_device is not always set in environments/ceph/configuration.yml. By default it should be 1.

Signed-off-by: Christian Berendt <berendt@osism.tech>