### PR TITLE
Add Ceph RGW validator playbook and S3 function test script

### DIFF
--- a/playbooks/ceph/files/rgw-validator.py
+++ b/playbooks/ceph/files/rgw-validator.py
@@ -100,20 +100,23 @@ def test_read_object(bucket_name, obj_key, obj_data):
     try:
         object = client.Object(bucket_name, obj_key)
         object_data = object.get()["Body"].read()
-        if object_data.decode() == obj_data:
-            test_result = "passed"
-            test_reason = "Read data matches expected result"
-        else:
-            test_failure = True
-            test_result = "failed"
-            test_reason = "Read data does not match expected result"
+        
+        # Test if read object data matches the data written
+        # by test_create_object. Not perfect but for now it works.
+        assert object_data.decode() == obj_data,\
+            "Read object data does not match expected result. "\
+            "Expected: '{}'\nGot: '{}'"\
+            .format(obj_data, obj_data.decode())
         return {
                 "test_name": "s3-read-object",
-                "result": test_result,
+                "result": "passed",
                 "data": {
-                    "test_reason": test_reason,
-                    "object_key": obj_key,
-                    "object_data": object.get()["Body"].read()
+                    "test_reason":
+                        "Read object data matches expected result.",
+                    "object_key":
+                        obj_key,
+                    "object_data":
+                        object.get()["Body"].read()
                     }
                 }
     except Exception as err:

--- a/playbooks/ceph/files/rgw-validator.py
+++ b/playbooks/ceph/files/rgw-validator.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+import os
+import argparse
+import uuid
+import urllib3
+import boto3
+from botocore.exceptions import ClientError
+
+def test_list_buckets():
+    global client
+    global test_failure
+    buckets = []
+    try:
+        for bucket in client.buckets.all():
+            buckets.append({
+                        "bucket_name": bucket.name,
+                        "creation_date": str(
+                            bucket.creation_date.strftime(
+                                "%m/%d/%Y, %H:%M:%S"
+                                )
+                            )
+                        })
+        return {
+                "test_name": "s3-list-buckets",
+                "result": "passed",
+                "data": buckets
+                }
+    except Exception as err:
+        test_failure = True
+        return {
+                "test_name": "s3-list-buckets",
+                "result": "failed",
+                "data": str(err)
+                }
+
+def test_create_bucket(bucket_name):
+    global client
+    global test_failure
+    try:
+        client.create_bucket(Bucket = bucket_name)
+        return {
+                "test_name": "s3-create-bucket",
+                "result": "passed",
+                "data": bucket_name
+                }
+    except Exception as err:
+        test_failure = True
+        return {
+                "test_name": "s3-create-bucket",
+                "result": "failed",
+                "data": str(err)
+                }
+
+def test_list_bucket_content(bucket_name):
+    global client
+    global test_failure
+    bucket_objects = []
+    try:
+        objects = client.Bucket(bucket_name).objects.all()
+        for obj in objects:
+            bucket_objects.append(obj.key)
+        return {
+                "test_name": "s3-list-bucket-content",
+                "result": "passed",
+                "data": bucket_objects
+                }
+    except Exception as err:
+        test_failure = True
+        return {
+                "test_name": "s3-list-bucket-content",
+                "result": "failed",
+                "data": str(err)
+                }
+
+def test_create_object(bucket_name, obj_key, obj_data):
+    global client
+    global test_failure
+    try:
+        object = client.Object(bucket_name, obj_key)
+        object.put(Body = obj_data)
+        return {
+                "test_name": "s3-create-object",
+                "result": "passed",
+                "data": {
+                    "object_key": obj_key,
+                    "object_data": obj_data
+                    }
+                }
+    except Exception as err:
+        test_failure = True
+        return {
+                "test_name": "s3-create-object",
+                "result": "failed",
+                "data": str(err)
+                }
+
+def test_read_object(bucket_name, obj_key, obj_data):
+    global client
+    global test_failure
+    try:
+        object = client.Object(bucket_name, obj_key)
+        object_data = object.get()["Body"].read()
+        if object_data.decode() == obj_data:
+            test_result = "passed"
+            test_reason = "Read data matches expected result"
+        else:
+            test_failure = True
+            test_result = "failed"
+            test_reason = "Read data does not match expected result"
+        return {
+                "test_name": "s3-read-object",
+                "result": test_result,
+                "data": {
+                    "test_reason": test_reason,
+                    "object_key": obj_key,
+                    "object_data": object.get()["Body"].read()
+                    }
+                }
+    except Exception as err:
+        test_failure = True
+        return {
+                "test_name": "s3-read-object",
+                "result": "failed",
+                "data": str(err)
+                }
+
+def main():
+    try:
+        global client
+        global test_failure
+        test_failure = False
+
+        # Read environment vars if set
+        ENV_VALIDATOR_ENDPOINT = os.environ.get(
+                    'VALIDATOR_ENDPOINT'
+                )
+        ENV_VALIDATOR_ACCESS_KEY = os.environ.get(
+                    'VALIDATOR_ACCESS_KEY'
+                )
+        ENV_VALIDATOR_SECRET_KEY = os.environ.get(
+                    'VALIDATOR_SECRET_KEY'
+                )
+        ENV_VALIDATOR_BUCKET = os.environ.get(
+                    'VALIDATOR_BUCKET',
+                    'osism-rgw-validator-testbucket'
+                )
+
+        # Configure argument parser
+        parser = argparse.ArgumentParser(
+                epilog='''Endpoint, Access Key ID, Secret access key
+                and bucket may also be specified via the environment
+                variables VALIDATOR_ENDPOINT, VALIDATOR_ACCESS_KEY,
+                VALIDATOR_SECRET_KEY and/or VALIDATOR_BUCKET'''
+                )
+        parser.add_argument(
+                "-k",
+                "--insecure",
+                help="Disable TLS certificate verification",
+                action="store_true"
+                )
+        parser.add_argument(
+                "--endpoint",
+                default=ENV_VALIDATOR_ENDPOINT,
+                required=ENV_VALIDATOR_ENDPOINT is None,
+                help="Endpoint URL e.g. http[s]://host.name[:<port>]"
+                )
+        parser.add_argument(
+                "--access_key",
+                default=ENV_VALIDATOR_ACCESS_KEY,
+                required=ENV_VALIDATOR_ACCESS_KEY is None,
+                help="S3 Access Key ID"
+                )
+        parser.add_argument(
+                "--secret_key",
+                default=ENV_VALIDATOR_SECRET_KEY,
+                required=ENV_VALIDATOR_SECRET_KEY is None,
+                help="S3 Secret access key"
+                )
+        parser.add_argument(
+                "--bucket",
+                default=ENV_VALIDATOR_BUCKET,
+                required=False,
+                help="Name of bucket for testing"
+                )
+
+        # Parse arguments
+        args = parser.parse_args()
+
+        # Set variables using "constant" naming for better readability
+        VALIDATOR_ENDPOINT=args.endpoint
+        VALIDATOR_ACCESS_KEY=args.access_key
+        VALIDATOR_SECRET_KEY=args.secret_key
+        VALIDATOR_BUCKET=args.bucket
+        VALIDATOR_NO_VERIFY_CERT=args.insecure
+
+        # Disable insecure warning if validation is disabled
+        if VALIDATOR_NO_VERIFY_CERT:
+            urllib3.disable_warnings(
+                    urllib3.exceptions.InsecureRequestWarning
+                    )
+
+        # Create boto3 S3 client
+        client = boto3.resource(
+                's3',
+                endpoint_url = VALIDATOR_ENDPOINT,
+                aws_access_key_id = VALIDATOR_ACCESS_KEY,
+                aws_secret_access_key = VALIDATOR_SECRET_KEY,
+                verify = not VALIDATOR_NO_VERIFY_CERT
+                )
+        
+        test_object_name = str(uuid.uuid4())
+        test_object_data = str(uuid.uuid4())
+
+        test_results = []
+
+        test_results.append(test_create_bucket(VALIDATOR_BUCKET))
+        test_results.append(test_list_buckets())
+        test_results.append(test_list_bucket_content(VALIDATOR_BUCKET))
+        test_results.append(
+            test_create_object(
+                    VALIDATOR_BUCKET,
+                    test_object_name,
+                    test_object_data
+                )
+            )
+        test_results.append(test_list_bucket_content(VALIDATOR_BUCKET))
+        test_results.append(
+            test_read_object(
+                    VALIDATOR_BUCKET,
+                    test_object_name,
+                    test_object_data
+                )
+            )
+
+        print(test_results);
+        if test_failure:
+            exit(1)
+        else:
+            exit(0)
+    except ClientError as err:
+        print("[{'client_error': '{}'}]".format(err))
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/playbooks/ceph/templates/ceph-rgws-validator-report.json.j2
+++ b/playbooks/ceph/templates/ceph-rgws-validator-report.json.j2
@@ -1,0 +1,1 @@
+{% if _validator_data is defined %}{{ _validator_data|to_nice_json }}{% endif %}

--- a/playbooks/ceph/validate-ceph-rgws.yml
+++ b/playbooks/ceph/validate-ceph-rgws.yml
@@ -38,20 +38,22 @@
     _rgws_reports_directory: "/opt/reports/validator"
     _rgws_venv_directory: "/opt/validator/rgw"
     _rgws_group_name: "{{ rgw_group_name|default('ceph-rgw') }}"
-  hosts: "{{ groups[_rgws_group_name] }}"
+  hosts: "{{ groups[_rgws_group_name]|default('ceph-rgw') }}"
+  strategy: linear
   gather_facts: true
   force_handlers: true
   tasks:
     # ansible_date_time is cached between runs,
     # so we need to get a timestamp another way
-    - name: Get timestamp for report file
-      ansible.builtin.shell:
+    - name: Get timestamp for report file # noqa: run-once[task]
+      ansible.builtin.command:
         cmd: "date --iso-8601=seconds"
       register: _rgws_report_timestamp
+      changed_when: false
       run_once: true
       delegate_to: "{{ groups['manager'][0] }}"
 
-    - name: Create report output directory
+    - name: Create report output directory # noqa: run-once[task]
       become: true
       ansible.builtin.file:
         path: "{{ _rgws_reports_directory }}"
@@ -62,12 +64,12 @@
       run_once: true
       delegate_to: "{{ groups['manager'][0] }}"
 
-    - name: Define report vars
+    - name: Define report vars # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_report_file:
           "{{ _rgws_reports_directory }}\
            /ceph-rgws-validator-\
-           {{ _rgws_report_timestamp.stdout|trim }}\
+           {{ _rgws_report_timestamp.stdout | trim }}\
            -report.json"
         _rgws_test_failed: false
         _rgws_result: "no-result"
@@ -78,7 +80,7 @@
         _rgws_instance_port: 8081
       run_once: true
 
-    - name: Create directory for python test script venv
+    - name: Create directory for python test script venv # noqa: run-once[task]
       become: true
       ansible.builtin.file:
         path: "{{ _rgws_venv_directory }}"
@@ -89,7 +91,7 @@
       run_once: true
       delegate_to: "{{ groups['manager'][0] }}"
 
-    - name: Create venv and install requirements
+    - name: Create venv and install requirements # noqa: run-once[task]
       ansible.builtin.pip:
         chdir: "{{ _rgws_venv_directory }}"
         name:
@@ -101,7 +103,7 @@
       run_once: true
       delegate_to: "{{ groups['manager'][0] }}"
 
-    - name: Copy S3 validator script
+    - name: Copy S3 validator script # noqa: run-once[task]
       become: true
       ansible.builtin.copy:
         src: files/rgw-validator.py
@@ -118,7 +120,7 @@
         _rgws_test_containers_existance_result: "no-result"
         _rgws_test_containers_existance_data: {}
 
-    - name: Get container info
+    - name: Get container info # noqa: args[module]
       community.docker.docker_container_info:
         name:
           "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
@@ -154,7 +156,7 @@
       ansible.builtin.set_fact:
         _rgws_container_status:
           "{{
-              _rgws_container_info.container['State']['Status']|
+              _rgws_container_info.container['State']['Status'] |
               default('not-found')
            }}"
         _rgws_test_containers_running_result: "no-result"
@@ -192,47 +194,48 @@
     # when trying to run the other tests. It's simpler to bail
     # out early than having to code around missing containers etc.
     - name: Fail and bail out early due to critical test failure(s)
+      when: _rgws_test_failed
       block:
         # We need to aggregate the test data from the different nodes
         # into one variable that gets written to the report because
         # of the way ansible handles facts across hosts.
         # This is split into multiple steps as apparently you can't
         # just use a fact you just set in the same set_fact task.
-        - name: Aggregate test results step one
+        - name: Aggregate test results step one # noqa: run-once[task]
           ansible.builtin.set_fact:
             _rgws_test_containers_existance_data:
               "{{
-                 play_hosts|
-                 map(
+                 play_hosts |
+                 map(\
                      'extract',
                      hostvars,
-                     '_rgws_test_containers_existance_data'
+                     '_rgws_test_containers_existance_data'\
                     )
                }}"
             _rgws_test_containers_running_data:
               "{{
-                 play_hosts|
-                 map(
+                 play_hosts |
+                 map(\
                      'extract',
                      hostvars,
-                     '_rgws_test_containers_running_data'
+                     '_rgws_test_containers_running_data'\
                     )
                }}"
             _rgws_reasons:
               "{{
-                 play_hosts|
-                 map(
+                 play_hosts |
+                 map(\
                      'extract',
                      hostvars,
-                     '_rgws_reasons'
-                    )|
+                     '_rgws_reasons'\
+                    ) |
                  join('\n')
                  + '\nSee test data for details.'
                }}"
           run_once: true
           delegate_to: "{{ groups['manager'][0] }}"
 
-        - name: Aggregate test results step two
+        - name: Aggregate test results step two # noqa: run-once[task]
           ansible.builtin.set_fact:
             _rgws_result: "failed"
             _rgws_tests:
@@ -249,7 +252,7 @@
           run_once: true
           delegate_to: "{{ groups['manager'][0] }}"
 
-        - name: Aggregate test results step three
+        - name: Aggregate test results step three # noqa: run-once[task]
           ansible.builtin.set_fact:
             _validator_data:
               validator: "ceph-rgws"
@@ -261,16 +264,15 @@
           changed_when: true
           notify:
             - Write report file
-      when: _rgws_test_failed
 
     # Flush handlers to write report file
-    - name: Flush handlers
+    - name: Flush handlers # noqa: run-once[task]
       ansible.builtin.meta: flush_handlers
       run_once: true
       delegate_to: "{{ groups['manager'][0] }}"
 
     # Print where to find report file
-    - name: Print report file information
+    - name: Print report file information # noqa: run-once[task]
       ansible.builtin.debug:
         msg:
           - "Validator run completed."
@@ -283,7 +285,7 @@
       when: _rgws_test_failed
 
     # Abort playbook execution after writing report
-    - name: Fail due to missing containers
+    - name: Fail due to missing containers # noqa: run-once[task]
       ansible.builtin.fail:
         msg: "Critical tests failed. See report file for details."
       run_once: true
@@ -291,13 +293,13 @@
       when: _rgws_test_failed
 
     # Test 3: List radosgw users
-    - name: Prepare user list test vars
+    - name: Prepare user list test vars # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_user_list_result: "no-result"
         _rgws_test_user_list_data: ""
       run_once: true
 
-    - name: Get RGW user list
+    - name: Get RGW user list # noqa: run-once[task] args[module]
       community.docker.docker_container_exec:
         container:
           "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
@@ -307,7 +309,7 @@
       run_once: true
 
     # Fail the user-list test if return code is not zero
-    - name: Fail user-list if return code is not acceptable
+    - name: Fail user-list if return code is not acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_failed: true
         _rgws_test_user_list_result: "failed"
@@ -323,7 +325,7 @@
         - _rgws_user_list_data.rc != 0
 
     # Pass the user-list test if return code is zero
-    - name: Pass user-list if return code is acceptable
+    - name: Pass user-list if return code is acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_user_list_result: "passed"
         _rgws_test_user_list_data:
@@ -333,13 +335,13 @@
         - _rgws_user_list_data.rc == 0
 
     # Test 4: List radosgw buckets
-    - name: Prepare bucket list test vars
+    - name: Prepare bucket list test vars # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_bucket_list_result: "no-result"
         _rgws_test_bucket_list_data: ""
       run_once: true
 
-    - name: Get RGW bucket list
+    - name: Get RGW bucket list # noqa: run-once[task] args[module]
       community.docker.docker_container_exec:
         container:
           "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
@@ -349,7 +351,7 @@
       run_once: true
 
     # Fail the bucket-list test if return code is not zero
-    - name: Fail bucket-list if return code is not acceptable
+    - name: Fail bucket-list if return code is not acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_failed: true
         _rgws_test_bucket_list_result: "failed"
@@ -365,7 +367,7 @@
         - _rgws_bucket_list_data.rc != 0
 
     # Pass the bucket-list test if return code is zero
-    - name: Pass bucket-list if return code is acceptable
+    - name: Pass bucket-list if return code is acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_bucket_list_result: "passed"
         _rgws_test_bucket_list_data:
@@ -375,7 +377,7 @@
         - _rgws_bucket_list_data.rc == 0
 
     # Test 5: Create radosgw validator test user
-    - name: Prepare user create test vars
+    - name: Prepare user create test vars # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_user_create_result: "no-result"
         _rgws_test_user_create_data: ""
@@ -383,7 +385,7 @@
           "osism-s3-validator-{{ _rgws_instance_name }}"
       run_once: true
 
-    - name: Fetch RGW test user info
+    - name: Fetch RGW test user info # noqa: run-once[task] args[module]
       community.docker.docker_container_exec:
         container:
           "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
@@ -396,7 +398,7 @@
         - _rgws_user_create_user_info_data.rc != 22
       run_once: true
 
-    - name: Create RGW test user (if not exists)
+    - name: Create RGW test user (if not exists) # noqa: run-once[task] args[module]
       community.docker.docker_container_exec:
         container:
           "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
@@ -409,7 +411,7 @@
       when: _rgws_user_create_user_info_data.rc != 0
 
     # Fail the user-create test if return code is not zero
-    - name: Fail user-create if return code is not acceptable
+    - name: Fail user-create if return code is not acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_failed: true
         _rgws_test_user_create_result: "failed"
@@ -428,7 +430,7 @@
         - _rgws_user_create_data.rc != 0
 
     # Pass the user-create test if return code is zero
-    - name: Pass user-create if return code is acceptable
+    - name: Pass user-create if return code is acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_user_create_result: "passed"
         _rgws_test_user_create_data:
@@ -439,47 +441,47 @@
         - _rgws_user_create_data.rc == 0
 
     # Test 6: Test S3 functionality through rgw-validator.py script
-    - name: Prepare S3 functionality test vars
+    - name: Prepare S3 functionality test vars # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_s3_functions_result: "no-result"
         _rgws_test_s3_functions_data: ""
       run_once: true
 
-    - name: Prepare S3 test user vars (user created)
+    - name: Prepare S3 test user vars (user created) # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_user_access_key:
           "{{
-             _rgws_user_create_data.stdout|
-             from_json|
+             _rgws_user_create_data.stdout |
+             from_json |
              json_query('keys[0].access_key')
            }}"
         _rgws_test_user_secret_key:
           "{{
-             _rgws_user_create_data.stdout|
-             from_json|
+             _rgws_user_create_data.stdout |
+             from_json |
              json_query('keys[0].secret_key')
            }}"
       run_once: true
       when: _rgws_user_create_user_info_data.rc != 0
 
-    - name: Prepare S3 test user vars (existing user)
+    - name: Prepare S3 test user vars (existing user) # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_user_access_key:
           "{{
-             _rgws_user_create_user_info_data.stdout|
-             from_json|
+             _rgws_user_create_user_info_data.stdout |
+             from_json |
              json_query('keys[0].access_key')
            }}"
         _rgws_test_user_secret_key:
           "{{
-             _rgws_user_create_user_info_data.stdout|
-             from_json|
+             _rgws_user_create_user_info_data.stdout |
+             from_json |
              json_query('keys[0].secret_key')
            }}"
       run_once: true
       when: _rgws_user_create_user_info_data.rc == 0
 
-    - name: Test S3 functionality
+    - name: Test S3 functionality # noqa: run-once[task]
       ansible.builtin.shell:
         cmd:
           ". {{ _rgws_venv_directory }}/bin/activate &&
@@ -494,14 +496,15 @@
           "osism-rgw-validator-{{ groups['manager'][0] }}"
       register: _rgws_s3_script_output
       ignore_errors: true
-      delegate_to: "{{ groups['manager'][0]}}"
+      changed_when: false
+      delegate_to: "{{ groups['manager'][0] }}"
       run_once: true
       when:
         - _rgws_test_user_access_key is defined
         - _rgws_test_user_secret_key is defined
 
     # Fail the s3-functions test if return code is not zero
-    - name: Fail s3-functions if return code is not acceptable
+    - name: Fail s3-functions if return code is not acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_failed: true
         _rgws_test_s3_functions_result: "failed"
@@ -515,7 +518,7 @@
         - _rgws_s3_script_output.rc != 0
 
     # Pass the s3-functions test if return code is zero
-    - name: Pass s3-functions if return code is acceptable
+    - name: Pass s3-functions if return code is acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_s3_functions_result: "passed"
         _rgws_test_s3_functions_data:
@@ -525,13 +528,13 @@
         - _rgws_s3_script_output.rc == 0
 
     # Test 7: Delete radosgw validator test user
-    - name: Prepare user delete test vars
+    - name: Prepare user delete test vars # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_user_delete_result: "no-result"
         _rgws_test_user_delete_data: ""
       run_once: true
 
-    - name: Fetch RGW test user info
+    - name: Fetch RGW test user info # noqa: run-once[task] args[module]
       community.docker.docker_container_exec:
         container:
           "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
@@ -544,7 +547,7 @@
         - _rgws_user_create_user_info_data.rc != 22
       run_once: true
 
-    - name: Delete RGW test user (if it exists)
+    - name: Delete RGW test user (if it exists) # noqa: run-once[task] args[module]
       community.docker.docker_container_exec:
         container:
           "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
@@ -557,7 +560,7 @@
       when: _rgws_user_delete_user_info_data.rc == 0
 
     # Fail the user-delete test if return code is not zero
-    - name: Fail user-delete if return code is not acceptable
+    - name: Fail user-delete if return code is not acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_failed: true
         _rgws_test_user_delete_result: "failed"
@@ -575,7 +578,7 @@
         - _rgws_user_delete_data.rc != 0
 
     # Pass the user-delete test if return code is zero
-    - name: Pass user-delete if return code is acceptable
+    - name: Pass user-delete if return code is acceptable # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_user_delete_result: "passed"
         _rgws_test_user_delete_data:
@@ -586,7 +589,7 @@
         - _rgws_user_delete_data.rc == 0
 
     # Set validation result to passed if no test failed
-    - name: Set validation result to passed if no test failed
+    - name: Set validation result to passed if no test failed # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_result: "passed"
         _rgws_reasons:
@@ -596,7 +599,7 @@
       when: not _rgws_test_failed
 
     # Set validation result to failed if a test failed
-    - name: Set validation result to failed if a test failed
+    - name: Set validation result to failed if a test failed # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_result: "failed"
       run_once: true
@@ -604,92 +607,92 @@
       when: _rgws_test_failed
 
     # Aggregate results for report file
-    - name: Aggregate test results step one
+    - name: Aggregate test results step one # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_test_containers_existance_data:
           "{{
-              play_hosts|
-              map(
+              play_hosts | 
+              map(\
                   'extract',
                   hostvars,
-                  '_rgws_test_containers_existance_data'
+                  '_rgws_test_containers_existance_data'\
                 )
             }}"
         _rgws_test_containers_running_data:
           "{{
-              play_hosts|
-              map(
+              play_hosts |
+              map(\
                   'extract',
                   hostvars,
-                  '_rgws_test_containers_running_data'
+                  '_rgws_test_containers_running_data'\
                 )
             }}"
         _rgws_test_user_list_data:
           "{{
-              play_hosts|
-              map(
+              play_hosts |
+              map(\
                   'extract',
                   hostvars,
-                  '_rgws_test_user_list_data'
-                )|
+                  '_rgws_test_user_list_data'\
+                ) |
               unique
             }}"
         _rgws_test_bucket_list_data:
           "{{
-              play_hosts|
-              map(
+              play_hosts |
+              map(\
                   'extract',
                   hostvars,
-                  '_rgws_test_bucket_list_data'
-                )|
+                  '_rgws_test_bucket_list_data'\
+                ) |
               unique
             }}"
         _rgws_test_user_create_data:
           "{{
-              play_hosts|
-              map(
+              play_hosts |
+              map(\
                   'extract',
                   hostvars,
-                  '_rgws_test_user_create_data'
-                )|
+                  '_rgws_test_user_create_data'\
+                ) |
               unique
             }}"
         _rgws_test_s3_functions_data:
           "{{
-              play_hosts|
-              map(
+              play_hosts |
+              map(\
                   'extract',
                   hostvars,
-                  '_rgws_test_s3_functions_data'
-                )|
+                  '_rgws_test_s3_functions_data'\
+                ) |
               unique
             }}"
         _rgws_test_user_delete_data:
           "{{
-              play_hosts|
-              map(
+              play_hosts |
+              map(\
                   'extract',
                   hostvars,
-                  '_rgws_test_user_delete_data'
-                )|
+                  '_rgws_test_user_delete_data'\
+                ) |
               unique
             }}"
         _rgws_reasons:
           "{{
-              play_hosts|
-              map(
+              play_hosts |
+              map(\
                   'extract',
                   hostvars,
-                  '_rgws_reasons'
-                )|
-              unique|
+                  '_rgws_reasons'\
+                ) |
+              unique |
               join('\n')
               + '\nSee test data for details.'
             }}"
       run_once: true
       delegate_to: "{{ groups['manager'][0] }}"
 
-    - name: Aggregate test results step two
+    - name: Aggregate test results step two # noqa: run-once[task]
       ansible.builtin.set_fact:
         _rgws_tests:
           - {
@@ -730,7 +733,7 @@
       run_once: true
       delegate_to: "{{ groups['manager'][0] }}"
 
-    - name: Aggregate test results step three
+    - name: Aggregate test results step three # noqa: run-once[task]
       ansible.builtin.set_fact:
         _validator_data:
           validator: "ceph-rgws"
@@ -744,13 +747,13 @@
         - Write report file
 
     # Flush handlers to write report file
-    - name: Flush handlers
+    - name: Flush handlers # noqa: run-once[task]
       ansible.builtin.meta: flush_handlers
       run_once: true
       delegate_to: "{{ groups['manager'][0] }}"
 
     # Print where to find report file
-    - name: Print report file information
+    - name: Print report file information # noqa: run-once[task]
       ansible.builtin.debug:
         msg:
           - "Validator run completed."
@@ -761,9 +764,10 @@
       run_once: true
       delegate_to: "{{ groups['manager'][0] }}"
   handlers:
-    - name: Write report file
+    - name: Write report file # noqa: run-once[task]
       ansible.builtin.template:
         src: "templates/ceph-rgws-validator-report.json.j2"
         dest: "{{ _rgws_report_file }}"
+        mode: '0644'
       delegate_to: "{{ groups['manager'][0] }}"
       run_once: true

--- a/playbooks/ceph/validate-ceph-rgws.yml
+++ b/playbooks/ceph/validate-ceph-rgws.yml
@@ -1,0 +1,769 @@
+---
+###
+# This playbook checks the following Ceph components
+# inside a OSISM-deployed Ceph cluster:
+# RADOS Gateway services:
+# Tests:
+# - All containers with radosgw are existing
+# - All containers with radosgw are running
+# - RADOS Gateway users and buckets can be listed
+# - RADOS Gateway test user can be created
+# - S3 functionality:
+# -- Listing buckets of test user
+# -- Creating bucket for testing
+# -- Putting objects
+# -- Retrieving objects
+# -- Deleting objects
+# -- Deleting test bucket
+# - RADOS Gateway test user can be deleted
+#
+# Test #1: Container existing
+# Test #2: Container running
+# Test #3: List radosgw users
+# Test #4: List radosgw buckets
+# Test #5: Create radosgw test user
+# Test #6: Test S3 functionality
+# Test #7: Delete radosgw test user
+#
+# This playbook can be used to validate that basic RADOS Gateway
+# functionality is present and S3 is working.
+# Swift functionality and Keystone authentication will not be tested.
+# To check other components use the other playbooks.
+# This playbook will create a JSON report file on
+# the first manager node in /opt/reports/validator
+###
+
+- name: Ceph validate rgws
+  vars:
+    _rgws_reports_directory: "/opt/reports/validator"
+    _rgws_venv_directory: "/opt/validator/rgw"
+    _rgws_group_name: "{{ rgw_group_name|default('ceph-rgw') }}"
+  hosts: "{{ groups[_rgws_group_name] }}"
+  gather_facts: true
+  force_handlers: true
+  tasks:
+    # ansible_date_time is cached between runs,
+    # so we need to get a timestamp another way
+    - name: Get timestamp for report file
+      ansible.builtin.shell:
+        cmd: "date --iso-8601=seconds"
+      register: _rgws_report_timestamp
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+
+    - name: Create report output directory
+      become: true
+      ansible.builtin.file:
+        path: "{{ _rgws_reports_directory }}"
+        state: directory
+        owner: "{{ operator_user }}"
+        group: "{{ operator_group }}"
+        recurse: true
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+
+    - name: Define report vars
+      ansible.builtin.set_fact:
+        _rgws_report_file:
+          "{{ _rgws_reports_directory }}\
+           /ceph-rgws-validator-\
+           {{ _rgws_report_timestamp.stdout|trim }}\
+           -report.json"
+        _rgws_test_failed: false
+        _rgws_result: "no-result"
+        _rgws_reasons: ""
+        _rgws_tests: []
+        # Currently these are hardcoded
+        _rgws_instance_name: "rgw0"
+        _rgws_instance_port: 8081
+      run_once: true
+
+    - name: Create directory for python test script venv
+      become: true
+      ansible.builtin.file:
+        path: "{{ _rgws_venv_directory }}"
+        state: directory
+        owner: "{{ operator_user }}"
+        group: "{{ operator_group }}"
+        recurse: true
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+
+    - name: Create venv and install requirements
+      ansible.builtin.pip:
+        chdir: "{{ _rgws_venv_directory }}"
+        name:
+          - urllib3
+          - boto3
+        state: present
+        virtualenv: "{{ _rgws_venv_directory }}"
+        virtualenv_python: python3
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+
+    - name: Copy S3 validator script
+      become: true
+      ansible.builtin.copy:
+        src: files/rgw-validator.py
+        dest: "{{ _rgws_venv_directory }}/"
+        owner: "{{ operator_user }}"
+        group: "{{ operator_group }}"
+        mode: "0755"
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+
+    # Test 1: Check for existance of radosgw containers
+    - name: Prepare test data for container existance test
+      ansible.builtin.set_fact:
+        _rgws_test_containers_existance_result: "no-result"
+        _rgws_test_containers_existance_data: {}
+
+    - name: Get container info
+      community.docker.docker_container_info:
+        name:
+          "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
+      register: _rgws_container_info
+
+    # Fail test if ceph-rgw container is missing on a host
+    - name: Set test result to failed if container is missing
+      ansible.builtin.set_fact:
+        _rgws_test_failed: true
+        _rgws_test_containers_existance_result: "failed"
+        _rgws_test_containers_existance_data:
+          "Container
+           'ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}'
+           missing on {{ inventory_hostname }}."
+        _rgws_reasons:
+          "{{ _rgws_reasons }}{{ ' ' if _rgws_reasons }}\
+          Test 'container-existance' failed on
+           {{ inventory_hostname }}."
+      when: not _rgws_container_info.exists
+
+    # Pass test if ceph-rgw is existing on the host under test
+    - name: Set test result to passed if container is existing
+      ansible.builtin.set_fact:
+        _rgws_test_containers_existance_result: "passed"
+        _rgws_test_containers_existance_data:
+          "Container
+           'ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}'
+           exists on {{ inventory_hostname }}."
+      when: _rgws_container_info.exists
+
+    # Test 2: Check that all ceph-rgw containers are running
+    - name: Prepare test data
+      ansible.builtin.set_fact:
+        _rgws_container_status:
+          "{{
+              _rgws_container_info.container['State']['Status']|
+              default('not-found')
+           }}"
+        _rgws_test_containers_running_result: "no-result"
+        _rgws_test_containers_running_data: ""
+
+    # Fail test if ceph-rgw container is not running on a host
+    - name: Set test result to failed if ceph-rgw is not running
+      ansible.builtin.set_fact:
+        _rgws_test_failed: true
+        _rgws_test_containers_running_result: "failed"
+        _rgws_test_containers_running_data:
+          "Container
+           'ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}'
+           not in running state on {{ inventory_hostname }}"
+        _rgws_reasons:
+          "{{ _rgws_reasons }}{{ ' ' if _rgws_reasons }}\
+          Test 'container-running' failed on
+           {{ inventory_hostname }}."
+      when:
+        _rgws_container_status != "running"
+
+    # Pass test if ceph-rgw container is running on a host
+    - name: Set test result to passed if ceph-rgw is running
+      ansible.builtin.set_fact:
+        _rgws_test_containers_running_result: "passed"
+        _rgws_test_containers_running_data:
+          "Container
+           'ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}'
+           is running on {{ inventory_hostname }}"
+      when:
+        _rgws_container_status == "running"
+
+    # I bail out early here if one of the two container tests failed
+    # as it indicates a major problem and could be problematic
+    # when trying to run the other tests. It's simpler to bail
+    # out early than having to code around missing containers etc.
+    - name: Fail and bail out early due to critical test failure(s)
+      block:
+        # We need to aggregate the test data from the different nodes
+        # into one variable that gets written to the report because
+        # of the way ansible handles facts across hosts.
+        # This is split into multiple steps as apparently you can't
+        # just use a fact you just set in the same set_fact task.
+        - name: Aggregate test results step one
+          ansible.builtin.set_fact:
+            _rgws_test_containers_existance_data:
+              "{{
+                 play_hosts|
+                 map(
+                     'extract',
+                     hostvars,
+                     '_rgws_test_containers_existance_data'
+                    )
+               }}"
+            _rgws_test_containers_running_data:
+              "{{
+                 play_hosts|
+                 map(
+                     'extract',
+                     hostvars,
+                     '_rgws_test_containers_running_data'
+                    )
+               }}"
+            _rgws_reasons:
+              "{{
+                 play_hosts|
+                 map(
+                     'extract',
+                     hostvars,
+                     '_rgws_reasons'
+                    )|
+                 join('\n')
+                 + '\nSee test data for details.'
+               }}"
+          run_once: true
+          delegate_to: "{{ groups['manager'][0] }}"
+
+        - name: Aggregate test results step two
+          ansible.builtin.set_fact:
+            _rgws_result: "failed"
+            _rgws_tests:
+              - {
+                name: "containers-existance",
+                result: "{{ _rgws_test_containers_existance_result }}",
+                data: "{{ _rgws_test_containers_existance_data }}"
+              }
+              - {
+                name: "containers-running",
+                result: "{{ _rgws_test_containers_running_result }}",
+                data: "{{ _rgws_test_containers_running_data }}"
+              }
+          run_once: true
+          delegate_to: "{{ groups['manager'][0] }}"
+
+        - name: Aggregate test results step three
+          ansible.builtin.set_fact:
+            _validator_data:
+              validator: "ceph-rgws"
+              validator_result: "{{ _rgws_result }}"
+              validator_reason: "{{ _rgws_reasons }}"
+              validator_tests: "{{ _rgws_tests }}"
+          run_once: true
+          delegate_to: "{{ groups['manager'][0] }}"
+          changed_when: true
+          notify:
+            - Write report file
+      when: _rgws_test_failed
+
+    # Flush handlers to write report file
+    - name: Flush handlers
+      ansible.builtin.meta: flush_handlers
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+
+    # Print where to find report file
+    - name: Print report file information
+      ansible.builtin.debug:
+        msg:
+          - "Validator run completed."
+          - "You can find the report file here:"
+          - "{{ _rgws_report_file }}"
+          - "on the following host:"
+          - "{{ groups['manager'][0] }}"
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+      when: _rgws_test_failed
+
+    # Abort playbook execution after writing report
+    - name: Fail due to missing containers
+      ansible.builtin.fail:
+        msg: "Critical tests failed. See report file for details."
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+      when: _rgws_test_failed
+
+    # Test 3: List radosgw users
+    - name: Prepare user list test vars
+      ansible.builtin.set_fact:
+        _rgws_test_user_list_result: "no-result"
+        _rgws_test_user_list_data: ""
+      run_once: true
+
+    - name: Get RGW user list
+      community.docker.docker_container_exec:
+        container:
+          "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
+        command: "radosgw-admin user list --format=json"
+      register: _rgws_user_list_data
+      ignore_errors: true
+      run_once: true
+
+    # Fail the user-list test if return code is not zero
+    - name: Fail user-list if return code is not acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_failed: true
+        _rgws_test_user_list_result: "failed"
+        _rgws_test_user_list_data:
+          "radosgw-admin user list returned non-zero exit code:\n\
+           StdOut: {{ _rgws_user_list_data.stdout }}\n\
+           StdErr: {{ _rgws_user_list_data.stderr }}"
+        _rgws_reasons:
+          "{{ _rgws_reasons }}{{ ' ' if _rgws_reasons }}\
+          Test 'user-list' failed."
+      run_once: true
+      when:
+        - _rgws_user_list_data.rc != 0
+
+    # Pass the user-list test if return code is zero
+    - name: Pass user-list if return code is acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_user_list_result: "passed"
+        _rgws_test_user_list_data:
+          "Listing RGW users was successful."
+      run_once: true
+      when:
+        - _rgws_user_list_data.rc == 0
+
+    # Test 4: List radosgw buckets
+    - name: Prepare bucket list test vars
+      ansible.builtin.set_fact:
+        _rgws_test_bucket_list_result: "no-result"
+        _rgws_test_bucket_list_data: ""
+      run_once: true
+
+    - name: Get RGW bucket list
+      community.docker.docker_container_exec:
+        container:
+          "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
+        command: "radosgw-admin bucket list --format=json"
+      register: _rgws_bucket_list_data
+      ignore_errors: true
+      run_once: true
+
+    # Fail the bucket-list test if return code is not zero
+    - name: Fail bucket-list if return code is not acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_failed: true
+        _rgws_test_bucket_list_result: "failed"
+        _rgws_test_bucket_list_data:
+          "radosgw-admin bucket list returned non-zero exit code:\n\
+           StdOut: {{ _rgws_bucket_list_data.stdout }}\n\
+           StdErr: {{ _rgws_bucket_list_data.stderr }}"
+        _rgws_reasons:
+          "{{ _rgws_reasons }}{{ ' ' if _rgws_reasons }}\
+          Test 'bucket-list' failed."
+      run_once: true
+      when:
+        - _rgws_bucket_list_data.rc != 0
+
+    # Pass the bucket-list test if return code is zero
+    - name: Pass bucket-list if return code is acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_bucket_list_result: "passed"
+        _rgws_test_bucket_list_data:
+          "Listing RGW buckets was successful."
+      run_once: true
+      when:
+        - _rgws_bucket_list_data.rc == 0
+
+    # Test 5: Create radosgw validator test user
+    - name: Prepare user create test vars
+      ansible.builtin.set_fact:
+        _rgws_test_user_create_result: "no-result"
+        _rgws_test_user_create_data: ""
+        _rgws_s3_username:
+          "osism-s3-validator-{{ _rgws_instance_name }}"
+      run_once: true
+
+    - name: Fetch RGW test user info
+      community.docker.docker_container_exec:
+        container:
+          "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
+        command:
+          "radosgw-admin user info --uid={{ _rgws_s3_username }}"
+      register: _rgws_user_create_user_info_data
+      ignore_errors: true
+      failed_when:
+        - _rgws_user_create_user_info_data.rc != 0
+        - _rgws_user_create_user_info_data.rc != 22
+      run_once: true
+
+    - name: Create RGW test user (if not exists)
+      community.docker.docker_container_exec:
+        container:
+          "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
+        command:
+          "radosgw-admin user create --uid={{ _rgws_s3_username }}
+           --display-name='OSISM RGW S3 validator test user'"
+      register: _rgws_user_create_data
+      ignore_errors: true
+      run_once: true
+      when: _rgws_user_create_user_info_data.rc != 0
+
+    # Fail the user-create test if return code is not zero
+    - name: Fail user-create if return code is not acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_failed: true
+        _rgws_test_user_create_result: "failed"
+        _rgws_test_user_create_data:
+          "radosgw-admin user create --uid={{ _rgws_s3_username }}
+           --display-name='OSISM RGW S3 validator test user'
+           returned non-zero exit code:\n\
+           StdOut: {{ _rgws_user_create_data.stdout }}\n\
+           StdErr: {{ _rgws_user_create_data.stderr }}"
+        _rgws_reasons:
+          "{{ _rgws_reasons }}{{ ' ' if _rgws_reasons }}\
+          Test 'user-create' failed."
+      run_once: true
+      when:
+        - _rgws_user_create_user_info_data.rc != 0
+        - _rgws_user_create_data.rc != 0
+
+    # Pass the user-create test if return code is zero
+    - name: Pass user-create if return code is acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_user_create_result: "passed"
+        _rgws_test_user_create_data:
+          "Creating RGW test user was successful."
+      run_once: true
+      when:
+        - _rgws_user_create_user_info_data.rc != 0
+        - _rgws_user_create_data.rc == 0
+
+    # Test 6: Test S3 functionality through rgw-validator.py script
+    - name: Prepare S3 functionality test vars
+      ansible.builtin.set_fact:
+        _rgws_test_s3_functions_result: "no-result"
+        _rgws_test_s3_functions_data: ""
+      run_once: true
+
+    - name: Prepare S3 test user vars (user created)
+      ansible.builtin.set_fact:
+        _rgws_test_user_access_key:
+          "{{
+             _rgws_user_create_data.stdout|
+             from_json|
+             json_query('keys[0].access_key')
+           }}"
+        _rgws_test_user_secret_key:
+          "{{
+             _rgws_user_create_data.stdout|
+             from_json|
+             json_query('keys[0].secret_key')
+           }}"
+      run_once: true
+      when: _rgws_user_create_user_info_data.rc != 0
+
+    - name: Prepare S3 test user vars (existing user)
+      ansible.builtin.set_fact:
+        _rgws_test_user_access_key:
+          "{{
+             _rgws_user_create_user_info_data.stdout|
+             from_json|
+             json_query('keys[0].access_key')
+           }}"
+        _rgws_test_user_secret_key:
+          "{{
+             _rgws_user_create_user_info_data.stdout|
+             from_json|
+             json_query('keys[0].secret_key')
+           }}"
+      run_once: true
+      when: _rgws_user_create_user_info_data.rc == 0
+
+    - name: Test S3 functionality
+      ansible.builtin.shell:
+        cmd:
+          ". {{ _rgws_venv_directory }}/bin/activate &&
+           python3 {{ _rgws_venv_directory }}/rgw-validator.py"
+      environment:
+        VALIDATOR_ENDPOINT:
+          "http://{{ groups[_rgws_group_name][0] }}:\
+           {{ _rgws_instance_port }}"
+        VALIDATOR_ACCESS_KEY: "{{ _rgws_test_user_access_key }}"
+        VALIDATOR_SECRET_KEY: "{{ _rgws_test_user_secret_key }}"
+        VALIDATOR_BUCKET:
+          "osism-rgw-validator-{{ groups['manager'][0] }}"
+      register: _rgws_s3_script_output
+      ignore_errors: true
+      delegate_to: "{{ groups['manager'][0]}}"
+      run_once: true
+      when:
+        - _rgws_test_user_access_key is defined
+        - _rgws_test_user_secret_key is defined
+
+    # Fail the s3-functions test if return code is not zero
+    - name: Fail s3-functions if return code is not acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_failed: true
+        _rgws_test_s3_functions_result: "failed"
+        _rgws_test_s3_functions_data:
+          "{{ _rgws_s3_script_output.stdout }}"
+        _rgws_reasons:
+          "{{ _rgws_reasons }}{{ ' ' if _rgws_reasons }}\
+          Test 's3-functions' failed."
+      run_once: true
+      when:
+        - _rgws_s3_script_output.rc != 0
+
+    # Pass the s3-functions test if return code is zero
+    - name: Pass s3-functions if return code is acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_s3_functions_result: "passed"
+        _rgws_test_s3_functions_data:
+          "{{ _rgws_s3_script_output.stdout }}"
+      run_once: true
+      when:
+        - _rgws_s3_script_output.rc == 0
+
+    # Test 7: Delete radosgw validator test user
+    - name: Prepare user delete test vars
+      ansible.builtin.set_fact:
+        _rgws_test_user_delete_result: "no-result"
+        _rgws_test_user_delete_data: ""
+      run_once: true
+
+    - name: Fetch RGW test user info
+      community.docker.docker_container_exec:
+        container:
+          "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
+        command:
+          "radosgw-admin user info --uid={{ _rgws_s3_username }}"
+      register: _rgws_user_delete_user_info_data
+      ignore_errors: true
+      failed_when:
+        - _rgws_user_create_user_info_data.rc != 0
+        - _rgws_user_create_user_info_data.rc != 22
+      run_once: true
+
+    - name: Delete RGW test user (if it exists)
+      community.docker.docker_container_exec:
+        container:
+          "ceph-rgw-{{ ansible_hostname }}-{{ _rgws_instance_name }}"
+        command:
+          "radosgw-admin user rm --uid={{ _rgws_s3_username }}
+           --purge-data"
+      register: _rgws_user_delete_data
+      ignore_errors: true
+      run_once: true
+      when: _rgws_user_delete_user_info_data.rc == 0
+
+    # Fail the user-delete test if return code is not zero
+    - name: Fail user-delete if return code is not acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_failed: true
+        _rgws_test_user_delete_result: "failed"
+        _rgws_test_user_delete_data:
+          "radosgw-admin user rm --uid={{ _rgws_s3_username }}
+           returned non-zero exit code:\n\
+           StdOut: {{ _rgws_user_delete_data.stdout }}\n\
+           StdErr: {{ _rgws_user_delete_data.stderr }}"
+        _rgws_reasons:
+          "{{ _rgws_reasons }}{{ ' ' if _rgws_reasons }}\
+          Test 'user-delete' failed."
+      run_once: true
+      when:
+        - _rgws_user_delete_user_info_data.rc == 0
+        - _rgws_user_delete_data.rc != 0
+
+    # Pass the user-delete test if return code is zero
+    - name: Pass user-delete if return code is acceptable
+      ansible.builtin.set_fact:
+        _rgws_test_user_delete_result: "passed"
+        _rgws_test_user_delete_data:
+          "Deleting RGW test user was successful."
+      run_once: true
+      when:
+        - _rgws_user_delete_user_info_data.rc == 0
+        - _rgws_user_delete_data.rc == 0
+
+    # Set validation result to passed if no test failed
+    - name: Set validation result to passed if no test failed
+      ansible.builtin.set_fact:
+        _rgws_result: "passed"
+        _rgws_reasons:
+          "All tests passed validation."
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+      when: not _rgws_test_failed
+
+    # Set validation result to failed if a test failed
+    - name: Set validation result to failed if a test failed
+      ansible.builtin.set_fact:
+        _rgws_result: "failed"
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+      when: _rgws_test_failed
+
+    # Aggregate results for report file
+    - name: Aggregate test results step one
+      ansible.builtin.set_fact:
+        _rgws_test_containers_existance_data:
+          "{{
+              play_hosts|
+              map(
+                  'extract',
+                  hostvars,
+                  '_rgws_test_containers_existance_data'
+                )
+            }}"
+        _rgws_test_containers_running_data:
+          "{{
+              play_hosts|
+              map(
+                  'extract',
+                  hostvars,
+                  '_rgws_test_containers_running_data'
+                )
+            }}"
+        _rgws_test_user_list_data:
+          "{{
+              play_hosts|
+              map(
+                  'extract',
+                  hostvars,
+                  '_rgws_test_user_list_data'
+                )|
+              unique
+            }}"
+        _rgws_test_bucket_list_data:
+          "{{
+              play_hosts|
+              map(
+                  'extract',
+                  hostvars,
+                  '_rgws_test_bucket_list_data'
+                )|
+              unique
+            }}"
+        _rgws_test_user_create_data:
+          "{{
+              play_hosts|
+              map(
+                  'extract',
+                  hostvars,
+                  '_rgws_test_user_create_data'
+                )|
+              unique
+            }}"
+        _rgws_test_s3_functions_data:
+          "{{
+              play_hosts|
+              map(
+                  'extract',
+                  hostvars,
+                  '_rgws_test_s3_functions_data'
+                )|
+              unique
+            }}"
+        _rgws_test_user_delete_data:
+          "{{
+              play_hosts|
+              map(
+                  'extract',
+                  hostvars,
+                  '_rgws_test_user_delete_data'
+                )|
+              unique
+            }}"
+        _rgws_reasons:
+          "{{
+              play_hosts|
+              map(
+                  'extract',
+                  hostvars,
+                  '_rgws_reasons'
+                )|
+              unique|
+              join('\n')
+              + '\nSee test data for details.'
+            }}"
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+
+    - name: Aggregate test results step two
+      ansible.builtin.set_fact:
+        _rgws_tests:
+          - {
+            name: "containers-existance",
+            result: "{{ _rgws_test_containers_existance_result }}",
+            data: "{{ _rgws_test_containers_existance_data }}"
+          }
+          - {
+            name: "containers-running",
+            result: "{{ _rgws_test_containers_running_result }}",
+            data: "{{ _rgws_test_containers_running_data }}"
+          }
+          - {
+            name: "user-list",
+            result: "{{ _rgws_test_user_list_result }}",
+            data: "{{ _rgws_test_user_list_data }}"
+          }
+          - {
+            name: "bucket-list",
+            result: "{{ _rgws_test_bucket_list_result }}",
+            data: "{{ _rgws_test_bucket_list_data }}"
+          }
+          - {
+            name: "user-create",
+            result: "{{ _rgws_test_user_create_result }}",
+            data: "{{ _rgws_test_user_create_data }}"
+          }
+          - {
+            name: "s3-functions",
+            result: "{{ _rgws_test_s3_functions_result }}",
+            data: "{{ _rgws_test_s3_functions_data }}"
+          }
+          - {
+            name: "user-delete",
+            result: "{{ _rgws_test_user_delete_result }}",
+            data: "{{ _rgws_test_user_delete_data }}"
+          }
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+
+    - name: Aggregate test results step three
+      ansible.builtin.set_fact:
+        _validator_data:
+          validator: "ceph-rgws"
+          validator_result: "{{ _rgws_result }}"
+          validator_reason: "{{ _rgws_reasons }}"
+          validator_tests: "{{ _rgws_tests }}"
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+      changed_when: true
+      notify:
+        - Write report file
+
+    # Flush handlers to write report file
+    - name: Flush handlers
+      ansible.builtin.meta: flush_handlers
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+
+    # Print where to find report file
+    - name: Print report file information
+      ansible.builtin.debug:
+        msg:
+          - "Validator run completed."
+          - "You can find the report file here:"
+          - "{{ _rgws_report_file }}"
+          - "on the following host:"
+          - "{{ groups['manager'][0] }}"
+      run_once: true
+      delegate_to: "{{ groups['manager'][0] }}"
+  handlers:
+    - name: Write report file
+      ansible.builtin.template:
+        src: "templates/ceph-rgws-validator-report.json.j2"
+        dest: "{{ _rgws_report_file }}"
+      delegate_to: "{{ groups['manager'][0] }}"
+      run_once: true


### PR DESCRIPTION
This adds the Ceph RGW validator playbook and S3 functionality testing script (which can also be used standalone if needed).

Related to osism/issues#429 and SovereignCloudStack/issues#28

Signed-off-by: Paul-Philipp Kuschy <kuschy@osism.tech>