### PR TITLE
Remove obsolete minikube playbook

### DIFF
--- a/playbooks/infrastructure-minikube.yml
+++ b/playbooks/infrastructure-minikube.yml
@@ -1,1 +1,0 @@
-infrastructure/minikube.yml

--- a/playbooks/infrastructure/minikube.yml
+++ b/playbooks/infrastructure/minikube.yml
@@ -1,7 +1,0 @@
----
-- name: Apply role minikube
-  hosts: "{{ hosts_minikube|default('minikube') }}"
-  serial: "{{ osism_serial['minikube']|default(osism_serial_default)|default(0) }}"
-
-  roles:
-    - role: osism.services.minikube


### PR DESCRIPTION
The minikube playbook and its associated file have been removed as they are no longer needed. This playbook was responsible for applying the minikube role to the specified hosts. However, the role itself is no longer used in the project, so the playbook has been deleted to clean up the codebase.