### PR TITLE
Remove obsolete jenkins playbook

### DIFF
--- a/playbooks/infrastructure-jenkins.yml
+++ b/playbooks/infrastructure-jenkins.yml
@@ -1,1 +1,0 @@
-infrastructure/jenkins.yml

--- a/playbooks/infrastructure/jenkins.yml
+++ b/playbooks/infrastructure/jenkins.yml
@@ -1,7 +1,0 @@
----
-- name: Apply role jenkins
-  hosts: "{{ hosts_jenkins|default('jenkins') }}"
-  serial: "{{ osism_serial['jenkins']|default('0') }}"
-
-  roles:
-    - role: osism.services.jenkins


### PR DESCRIPTION
The jenkins playbook and its associated file have been removed as they are no longer needed. This playbook was responsible for applying the jenkins role to the specified hosts. However, the role itself is no longer used in the project, so the playbook has been deleted to clean up the codebase.