### PR TITLE
Remove obsolete jenkins playbook

### DIFF
--- a/playbooks/infrastructure-rundeck.yml
+++ b/playbooks/infrastructure-rundeck.yml
@@ -1,1 +1,0 @@
-infrastructure/rundeck.yml

--- a/playbooks/infrastructure/rundeck.yml
+++ b/playbooks/infrastructure/rundeck.yml
@@ -1,7 +1,0 @@
----
-- name: Apply role rundeck
-  hosts: "{{ hosts_rundeck|default('rundeck') }}"
-  serial: "{{ osism_serial['rundeck']|default('0') }}"
-
-  roles:
-    - role: osism.services.rundeck


### PR DESCRIPTION
The rundeck playbook and its associated file have been removed as they are no longer needed. This playbook was responsible for applying the rundeck role to the specified hosts. However, the role itself is no longer used in the project, so the playbook has been deleted to clean up the codebase.