### PR TITLE
Remove "Delete nova database records where instance_uuid is NULL" task

### DIFF
--- a/playbooks/generic/cleanup-databases.yml
+++ b/playbooks/generic/cleanup-databases.yml
@@ -66,13 +66,3 @@
       when:
         - container_nova_api.exists
         - database_nova_cleanup | bool
-
-    - name: Delete nova database records where instance_uuid is NULL
-      ansible.builtin.command: docker exec nova_api nova-manage db null_instance_uuid_scan --delete
-      async: "{{ database_cleanup_timeout }}"
-      poll: 5
-      tags: nova
-      changed_when: true
-      when:
-        - container_nova_api.exists
-        - database_nova_cleanup | bool


### PR DESCRIPTION
The db null_instance_uuid_scan command is not longer usable in nova-manage.