### PR TITLE
Allow to copy custom ceph keys

### DIFF
--- a/playbooks/manager/copy-ceph-keys.yml
+++ b/playbooks/manager/copy-ceph-keys.yml
@@ -4,6 +4,7 @@
 
   vars:
     ceph_ansible_container_name: ceph-ansible
+    ceph_custom_keys: {}
     ceph_infrastructure_keys:
       - src: ceph.client.admin.keyring
         dest: "{{ configuration_directory }}/environments/infrastructure/files/ceph/ceph.client.admin.keyring"
@@ -38,6 +39,8 @@
       environment:
         INTERACTIVE: "false"
       changed_when: true
+      tags:
+        - fetch
 
     - name: Copy ceph infrastructure keys to the configuration repository
       ansible.builtin.command: "docker cp {{ ceph_ansible_container_name }}:/share/{{ ceph_cluster_fsid }}/etc/ceph/{{ item.src }} {{ item.dest }}"
@@ -56,3 +59,10 @@
       loop: "{{ ceph_kolla_keys }}"
       tags:
         - kolla
+
+    - name: Copy ceph custom keys to the configuration repository
+      ansible.builtin.command: "docker cp {{ ceph_ansible_container_name }}:/share/{{ ceph_cluster_fsid }}/etc/ceph/{{ item.src }} {{ item.dest }}"
+      changed_when: true
+      loop: "{{ ceph_custom_keys }}"
+      tags:
+        - custom


### PR DESCRIPTION
That's possible with the new paramater ceph_custom_keys:

```
ceph_custom_keys:
  - src: ceph.client.manila1.keyring dest: "{{ configuration_directory }}/environments/kolla/files/overlays/manila/ceph.client.manila1.keyring"
```

Part of osism/issues#909