### PR TITLE
Add infrastructure/kubernetes-label-nodes play

### DIFF
--- a/playbooks/infrastructure-kubernetes-label-nodes.yml
+++ b/playbooks/infrastructure-kubernetes-label-nodes.yml
@@ -1,0 +1,1 @@
+infrastructure/kubernetes-label-nodes.yml

--- a/playbooks/infrastructure/kubernetes-label-nodes.yml
+++ b/playbooks/infrastructure/kubernetes-label-nodes.yml
@@ -1,0 +1,60 @@
+---
+- name: Label nodes
+  hosts: localhost
+  connection: local
+
+  tasks:
+    - name: Add control-plane label to all hosts in group control
+      ansible.builtin.shell: |
+        set -o pipefail
+
+        export KUBECONFIG=/share/kubeconfig
+        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/control-plane=true
+      args:
+        executable: /bin/bash
+      changed_when: false
+      loop: "{{ groups['control'] }}"
+
+    - name: Add compute-plane label to all hosts in group compute
+      ansible.builtin.shell: |
+        set -o pipefail
+
+        export KUBECONFIG=/share/kubeconfig
+        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/compute-plane=true
+      args:
+        executable: /bin/bash
+      changed_when: false
+      loop: "{{ groups['compute'] }}"
+
+    - name: Add network-plane label to all hosts in group network
+      ansible.builtin.shell: |
+        set -o pipefail
+
+        export KUBECONFIG=/share/kubeconfig
+        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/network-plane=true
+      args:
+        executable: /bin/bash
+      changed_when: false
+      loop: "{{ groups['network'] }}"
+
+    - name: Add management-plane label to all hosts in group manager
+      ansible.builtin.shell: |
+        set -o pipefail
+
+        export KUBECONFIG=/share/kubeconfig
+        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/management-plane=true
+      args:
+        executable: /bin/bash
+      changed_when: false
+      loop: "{{ groups['manager'] }}"
+
+    - name: Add monitoring-plane label to all hosts in group monitoring
+      ansible.builtin.shell: |
+        set -o pipefail
+
+        export KUBECONFIG=/share/kubeconfig
+        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/monitoring-plane=true
+      args:
+        executable: /bin/bash
+      changed_when: false
+      loop: "{{ groups['monitoring'] }}"

--- a/playbooks/infrastructure/kubernetes.yml
+++ b/playbooks/infrastructure/kubernetes.yml
@@ -7,3 +7,6 @@
 
 - name: Run kubeconfig play
   ansible.builtin.import_playbook: /ansible/infrastructure/kubeconfig.yml
+
+- name: Run kubernetes-label-nodes play
+  ansible.builtin.import_playbook: /ansible/infrastructure/kubernetes-label-nodes.yml


### PR DESCRIPTION
Adds labels to the nodes in a Kubernetes cluster according to their inventory groups in Ansible.

* node-role.osism.tech/compute-plane
* node-role.osism.tech/control-plane
* node-role.osism.tech/management-plane
* node-role.osism.tech/monitoring-plane
* node-role.osism.tech/network-plane

Closes osism/issues#855