### PR TITLE
manager: add sshconfig to the bootstrap play

### DIFF
--- a/playbooks/manager/bootstrap.yml
+++ b/playbooks/manager/bootstrap.yml
@@ -12,6 +12,13 @@
     - role: osism.commons.proxy
       tags: proxy
 
+    - role: osism.commons.sshconfig
+      # This ensures that only any extra SSH configuration configured
+      # is written to the Manager at this point.
+      vars:
+        sshconfig_private_key_file: ""
+      tags: sshconfig
+
     - role: osism.commons.resolvconf
       tags: resolvconf
 


### PR DESCRIPTION
There are clusters where it is necessary to set SSH configuration before the configuration repository can be cloned via SSH.

If the osism.commons.sshconfig is already applied when the manager is bootstrapped, it is possible to store additional SSH client configurations using the sshconfig_extra parameter.