### PR TITLE
manager: add certificates to the bootstrap play

### DIFF
--- a/playbooks/manager/bootstrap.yml
+++ b/playbooks/manager/bootstrap.yml
@@ -19,6 +19,9 @@
         sshconfig_private_key_file: ""
       tags: sshconfig
 
+    - role: osism.commons.certificates
+      tags: certificates
+
     - role: osism.commons.resolvconf
       tags: resolvconf
 


### PR DESCRIPTION
There are clusters where it is necessary to add a custom CA before the configuration repository can be cloned via SSH.