### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/add-limits-to-bootstrap-and-maintenance-936754bee09f2568.yaml
+++ b/releasenotes/notes/add-limits-to-bootstrap-and-maintenance-936754bee09f2568.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    osism.commons.limits is now part of the generic/bootstrap
-    and generic/maintenance plays.

--- a/releasenotes/notes/ansible-strategy-linear-4129b45c5f2bc965.yaml
+++ b/releasenotes/notes/ansible-strategy-linear-4129b45c5f2bc965.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Use linear as default Ansible strategy everywhere. This avoids especially issue
-    in ARA.

--- a/releasenotes/notes/cleanup-requirements-d7d956a46e04706d.yaml
+++ b/releasenotes/notes/cleanup-requirements-d7d956a46e04706d.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    The old Ansible roles `arista.cvp`, `arista.eos`, and `community.zabbix` were removed.

--- a/releasenotes/notes/infrastructure-kubeconfig-d8152bc999ef12b5.yaml
+++ b/releasenotes/notes/infrastructure-kubeconfig-d8152bc999ef12b5.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Add `infrastructure/kubeconfig` play to prepare the `kubeconfig`
-    file.

--- a/releasenotes/notes/k3s-always-install-kubectl-76d73a002e5866be.yaml
+++ b/releasenotes/notes/k3s-always-install-kubectl-76d73a002e5866be.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    In the `k3s` play always install the `kubectl` package.

--- a/releasenotes/notes/kubectl-fa8af4508bd53f5a.yaml
+++ b/releasenotes/notes/kubectl-fa8af4508bd53f5a.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Add `kubectl` play in the `infrastructure` environment.

--- a/releasenotes/notes/limits-802014fa470b6406.yaml
+++ b/releasenotes/notes/limits-802014fa470b6406.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    With the `generic/limits` play it is possible to set the
-    PAM limits of a host with the help of the osism.commons.limits
-    role.

--- a/releasenotes/notes/manager-copy-octavia-certificates-b2fd8cb8b97b1745.yaml
+++ b/releasenotes/notes/manager-copy-octavia-certificates-b2fd8cb8b97b1745.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    Add playbook to copy generated octavia certificates from the `/share`
-    volume to the configuration repository. Certificates can be generated
-    with `osism apply octavia-certificates`.

--- a/releasenotes/notes/remove-patchman-0d2362e6056c92ed.yaml
+++ b/releasenotes/notes/remove-patchman-0d2362e6056c92ed.yaml
@@ -1,5 +1,0 @@
----
-upgrade:
-  - |
-    The Patchman playbooks were deprecated with OSISM 6.0.0 and have now been removed.
-    The Patchman service is no longer usable in OSISM.

--- a/releasenotes/notes/remove-sysdig-8d19431597a46190.yaml
+++ b/releasenotes/notes/remove-sysdig-8d19431597a46190.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Remove `generic/sysdig` play.

--- a/releasenotes/notes/state-bootstrap-9641a87661cc65a6.yaml
+++ b/releasenotes/notes/state-bootstrap-9641a87661cc65a6.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the `generic/state-bootstrap` play it is possible to set and unset the
-    bootstrap state of a host.

--- a/releasenotes/notes/state-maintenance-b97cc72ef19367e9.yaml
+++ b/releasenotes/notes/state-maintenance-b97cc72ef19367e9.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the `generic/state-maintenance` play it is possible to set and unset the
-    maintenance state of a host.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.