### PR TITLE
hddtemp: Remove ansible_lsb.major_release condition

### DIFF
--- a/playbooks/generic/bootstrap.yml
+++ b/playbooks/generic/bootstrap.yml
@@ -59,7 +59,6 @@
     - role: osism.commons.services
     - role: osism.commons.motd
     - role: osism.services.hddtemp
-      when: ansible_lsb.major_release|int < 22
     - role: osism.services.rng
     - role: osism.services.smartd
     - role: osism.commons.cleanup

--- a/playbooks/generic/hddtemp.yml
+++ b/playbooks/generic/hddtemp.yml
@@ -6,4 +6,3 @@
 
   roles:
     - role: osism.services.hddtemp
-      when: ansible_lsb.major_release|int < 22

--- a/playbooks/generic/maintenance.yml
+++ b/playbooks/generic/maintenance.yml
@@ -79,7 +79,6 @@
     - role: osism.commons.services
     - role: osism.commons.motd
     - role: osism.services.hddtemp
-      when: ansible_lsb.major_release|int < 22
     - role: osism.services.rng
     - role: osism.services.smartd
     - role: osism.commons.cleanup


### PR DESCRIPTION
Remove `ansible_lsb.major_release` condition in hddtemp role

The condition `ansible_lsb.major_release|int < 22` in the hddtemp role is causing errors during testbed deployment on CentOS systems. This is because the `ansible_lsb.major_release` fact is often unavailable or an empty dictionary on CentOS, leading to the error: "error while evaluating conditional (ansible_lsb.major_release|int < 22): 'dict object' has no attribute 'major_release'".

The `ansible_lsb.major_release` fact is populated by the `lsb_release` command, which requires the `redhat-lsb-core` package to be installed on CentOS/RHEL systems. However, this package is not installed by default and has been deprecated on CentOS Stream 9.

cf. https://github.com/osism/testbed/pull/2229
