### PR TITLE
change default group

### DIFF
--- a/playbooks/generic/auditd.yml
+++ b/playbooks/generic/auditd.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Apply role auditd
   hosts:
-    - "{{ hosts_auditd|default('all') }}"
+    - "{{ hosts_auditd|default(hosts_default_group|default('generic')) }}"
     - "&enable_auditd_True"
   serial: "{{ osism_serial['auditd']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/certificates.yml
+++ b/playbooks/generic/certificates.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role certificates
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['certificates']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/check-reboot.yml
+++ b/playbooks/generic/check-reboot.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if system reboot is required
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 
   tasks:

--- a/playbooks/generic/chrony-force-sync.yml
+++ b/playbooks/generic/chrony-force-sync.yml
@@ -1,6 +1,6 @@
 ---
 - name: Force time sync with chronyc
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['chrony-force-sync']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/chrony.yml
+++ b/playbooks/generic/chrony.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Apply role chrony
   hosts:
-    - "{{ hosts_chrony|default('all') }}"
+    - "{{ hosts_chrony|default(hosts_default_group|default('generic')) }}"
     - "&enable_chrony_True"
   serial: "{{ osism_serial['chrony']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/clamav.yml
+++ b/playbooks/generic/clamav.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role clamav
-  hosts: "{{ hosts_clamav|default('all') }}"
+  hosts: "{{ hosts_clamav|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['clamav']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/clean-obsolet-service.yml
+++ b/playbooks/generic/clean-obsolet-service.yml
@@ -1,6 +1,6 @@
 ---
 - name: Clean up obsolet service configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   vars:

--- a/playbooks/generic/cleanup-container-images.yml
+++ b/playbooks/generic/cleanup-container-images.yml
@@ -1,6 +1,6 @@
 ---
 - name: Cleanup container images
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['docker_cleanup']|default('0') }}"
 
   vars_prompt:

--- a/playbooks/generic/cleanup-docker-images.yml
+++ b/playbooks/generic/cleanup-docker-images.yml
@@ -1,6 +1,6 @@
 ---
 - name: Cleanup docker images
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['docker_cleanup']|default('0') }}"
 
   vars_prompt:

--- a/playbooks/generic/cleanup-docker.yml
+++ b/playbooks/generic/cleanup-docker.yml
@@ -1,6 +1,6 @@
 ---
 - name: Cleanup docker
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['docker_cleanup']|default('1') }}"
 
   vars_prompt:

--- a/playbooks/generic/cleanup.yml
+++ b/playbooks/generic/cleanup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role cleanup
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['cleanup']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/configfs.yml
+++ b/playbooks/generic/configfs.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Apply role configfs
   hosts:
-    - "{{ hosts_configfs|default('all') }}"
+    - "{{ hosts_configfs|default(hosts_default_group|default('generic')) }}"
     - "&enable_configfs_True"
   serial: "{{ osism_serial['configs']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/containerd.yml
+++ b/playbooks/generic/containerd.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Apply role containerd
   hosts:
-    - "{{ hosts_containerd|default('all') }}"
+    - "{{ hosts_containerd|default(hosts_default_group|default('generic')) }}"
     - "&enable_containerd_True"
   serial: "{{ osism_serial['containerd']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/docker-compose.yml
+++ b/playbooks/generic/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:

--- a/playbooks/generic/docker-login.yml
+++ b/playbooks/generic/docker-login.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:

--- a/playbooks/generic/docker.yml
+++ b/playbooks/generic/docker.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:

--- a/playbooks/generic/dotfiles.yml
+++ b/playbooks/generic/dotfiles.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role geerlingguy.dotfiles
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 
   roles:

--- a/playbooks/generic/dump-facts.yml
+++ b/playbooks/generic/dump-facts.yml
@@ -1,7 +1,7 @@
 ---
 - name: Print all available facts
   ignore_unreachable: true
-  hosts: "{{ hosts_facts|default('all') }}"
+  hosts: "{{ hosts_facts|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['facts']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/facts.yml
+++ b/playbooks/generic/facts.yml
@@ -1,7 +1,7 @@
 ---
 - name: Apply role facts
   ignore_unreachable: true
-  hosts: "{{ hosts_facts|default('all') }}"
+  hosts: "{{ hosts_facts|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['facts']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 
@@ -10,7 +10,7 @@
 
 - name: Gather facts for all hosts
   ignore_unreachable: true
-  hosts: "{{ hosts_facts|default('all') }}"
+  hosts: "{{ hosts_facts|default(hosts_default_group|default('generic')) }}"
   gather_facts: false
 
   tasks:

--- a/playbooks/generic/fail2ban.yml
+++ b/playbooks/generic/fail2ban.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role fail2ban
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['fail2ban']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/falco.yml
+++ b/playbooks/generic/falco.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role falco
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['falco']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/firewall.yml
+++ b/playbooks/generic/firewall.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role firewall
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['firewall']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/frr.yml
+++ b/playbooks/generic/frr.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Apply role frr
   hosts:
-    - "{{ hosts_frr|default('all') }}"
+    - "{{ hosts_frr|default(hosts_default_group|default('generic')) }}"
     - "&enable_frr_True"
   serial: "{{ osism_serial['frr']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/grub.yml
+++ b/playbooks/generic/grub.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role debops.grub
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   become: true
   serial: "{{ osism_serial['grub']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/halt.yml
+++ b/playbooks/generic/halt.yml
@@ -1,6 +1,6 @@
 ---
 - name: Reboot systems
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   become: true
   serial: "{{ osism_serial['halt']|default('1') }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/hardening.yml
+++ b/playbooks/generic/hardening.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role hardening
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['hardening']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/hostname.yml
+++ b/playbooks/generic/hostname.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role hostname
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['hostname']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/hosts.yml
+++ b/playbooks/generic/hosts.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role hosts
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['hosts']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/ipmitool.yml
+++ b/playbooks/generic/ipmitool.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role ipmitool
-  hosts: "{{ hosts_ipmitool|default('all') }}"
+  hosts: "{{ hosts_ipmitool|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['ipmitool']|default('0') }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/journald.yml
+++ b/playbooks/generic/journald.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role journald
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['journald']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/kernel-modules.yml
+++ b/playbooks/generic/kernel-modules.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role kernel_modules
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['kernel_modules']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/limits.yml
+++ b/playbooks/generic/limits.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role limits
-  hosts: "{{ hosts_limits|default('all') }}"
+  hosts: "{{ hosts_limits|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['limits']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/lldpd.yml
+++ b/playbooks/generic/lldpd.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Apply role lldpd
   hosts:
-    - "{{ hosts_lldpd|default('all') }}"
+    - "{{ hosts_lldpd|default(hosts_default_group|default('generic')) }}"
     - "&enable_lldpd_True"
   serial: "{{ osism_serial['lldpd']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/lynis.yml
+++ b/playbooks/generic/lynis.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Apply role lynis
   hosts:
-    - "{{ hosts_lynis|default('all') }}"
+    - "{{ hosts_lynis|default(hosts_default_group|default('generic')) }}"
     - "&enable_lynis_True"
   serial: "{{ osism_serial['lynis']|default('0') }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/manage-container.yml
+++ b/playbooks/generic/manage-container.yml
@@ -1,6 +1,6 @@
 ---
 - name: Manage container
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['manage_container']|default(1) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/manage-service.yml
+++ b/playbooks/generic/manage-service.yml
@@ -1,6 +1,6 @@
 ---
 - name: Manage service
-  hosts: "{{ hosts_manage_service|default('all') }}"
+  hosts: "{{ hosts_manage_service|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['manage_service']|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/microcode.yml
+++ b/playbooks/generic/microcode.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role microcode
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['microcode']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/migrate-apt-keys.yml
+++ b/playbooks/generic/migrate-apt-keys.yml
@@ -10,7 +10,7 @@
 # https://github.com/osism/issues/issues/381
 ---
 - name: Fix "Key is stored in legacy trusted.gpg keyring" warning
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
 
   tasks:
     - name: Check /etc/apt/trusted.gpg file

--- a/playbooks/generic/motd.yml
+++ b/playbooks/generic/motd.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role motd
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['motd']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/network.yml
+++ b/playbooks/generic/network.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role network
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['network']|default('1') }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/operator.yml
+++ b/playbooks/generic/operator.yml
@@ -1,6 +1,6 @@
 ---
 - name: Make ssh pipelining working
-  hosts: "{{ hosts_operator|default('all') }}"
+  hosts: "{{ hosts_operator|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['pipelining']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 
@@ -17,7 +17,7 @@
         mode: 0440
 
 - name: Apply role operator
-  hosts: "{{ hosts_operator|default('all') }}"
+  hosts: "{{ hosts_operator|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['operator']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/packages.yml
+++ b/playbooks/generic/packages.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role packages
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['packages']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/ping.yml
+++ b/playbooks/generic/ping.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ping systems
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['ping']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
   gather_facts: false

--- a/playbooks/generic/proxy.yml
+++ b/playbooks/generic/proxy.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role proxy
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['proxy']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/python.yml
+++ b/playbooks/generic/python.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install python environment
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/python3.yml
+++ b/playbooks/generic/python3.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install python3 environment
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/reboot.yml
+++ b/playbooks/generic/reboot.yml
@@ -1,6 +1,6 @@
 ---
 - name: Reboot systems
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   become: true
   serial: "{{ osism_serial['reboot']|default('1') }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/remove-cockpit.yml
+++ b/playbooks/generic/remove-cockpit.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Remove cockpit
   hosts:
-    - "{{ hosts_cockpit|default('all') }}"
+    - "{{ hosts_cockpit|default(hosts_default_group|default('generic')) }}"
     - "&enable_cockpit_True"
   serial: "{{ osism_serial['cockpit']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/remove-deploy-user.yml
+++ b/playbooks/generic/remove-deploy-user.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove deploy user
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['remove_deploy_user']|default('0') }}"
 
   vars:

--- a/playbooks/generic/remove-panko.yml
+++ b/playbooks/generic/remove-panko.yml
@@ -1,6 +1,6 @@
 ---
 - name: Clean up obsolet service configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   vars:

--- a/playbooks/generic/remove-skydive.yml
+++ b/playbooks/generic/remove-skydive.yml
@@ -1,6 +1,6 @@
 ---
 - name: Clean up obsolet service configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   vars:

--- a/playbooks/generic/repository.yml
+++ b/playbooks/generic/repository.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role repository
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['repository']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/resolvconf.yml
+++ b/playbooks/generic/resolvconf.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role resolvconf
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['resolvconf']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/rng.yml
+++ b/playbooks/generic/rng.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role rng
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['rng']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/rsyslog.yml
+++ b/playbooks/generic/rsyslog.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role rsyslog
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['rsyslog']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/runc.yml
+++ b/playbooks/generic/runc.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Apply role runc
   hosts:
-    - "{{ hosts_runc|default('all') }}"
+    - "{{ hosts_runc|default(hosts_default_group|default('generic')) }}"
     - "&enable_runc_True"
   serial: "{{ osism_serial['runc']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/services.yml
+++ b/playbooks/generic/services.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role services
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['services']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/sosreport.yml
+++ b/playbooks/generic/sosreport.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role sosreport
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
   serial: "{{ osism_serial['sosreport']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/generic/state-bootstrap.yml
+++ b/playbooks/generic/state-bootstrap.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set bootstrap state
-  hosts: "{{ hosts_bootstrap|default('all') }}"
+  hosts: "{{ hosts_bootstrap|default(hosts_default_group|default('generic')) }}"
 
   vars:
     status: "True"

--- a/playbooks/generic/state-maintenance.yml
+++ b/playbooks/generic/state-maintenance.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set maintenance state
-  hosts: "{{ hosts_maintenance|default('all') }}"
+  hosts: "{{ hosts_maintenance|default(hosts_default_group|default('generic')) }}"
 
   vars:
     status: "True"

--- a/playbooks/generic/state-role.yml
+++ b/playbooks/generic/state-role.yml
@@ -1,6 +1,6 @@
 ---
 - name: Store status and time of the last execution of a role
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: 0
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/state.yml
+++ b/playbooks/generic/state.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role state
-  hosts: "{{ hosts_state|default('all') }}"
+  hosts: "{{ hosts_state|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['state']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/sysctl.yml
+++ b/playbooks/generic/sysctl.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role sysctl
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['sysctl']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/systohc.yml
+++ b/playbooks/generic/systohc.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role systohc
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['systohc']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/timezone.yml
+++ b/playbooks/generic/timezone.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role timezone
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['timezone']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/trivy.yml
+++ b/playbooks/generic/trivy.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -14,7 +14,7 @@
 
 - name: Apply role trivy
   hosts:
-    - "{{ hosts_trivy|default('all') }}"
+    - "{{ hosts_trivy|default(hosts_default_group|default('generic')) }}"
     - "&enable_trivy_True"
   serial: "{{ osism_serial['trivy']|default('0') }}"
 

--- a/playbooks/generic/ubuntu22-cis.yml
+++ b/playbooks/generic/ubuntu22-cis.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role ubuntu22-cis
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['ubuntu22-cis']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/upgrade-packages.yml
+++ b/playbooks/generic/upgrade-packages.yml
@@ -1,6 +1,6 @@
 ---
 - name: Upgrade packages
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['upgrade_packages']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/user.yml
+++ b/playbooks/generic/user.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role user
-  hosts: "{{ hosts_user|default('all') }}"
+  hosts: "{{ hosts_user|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['user']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/utilities.yml
+++ b/playbooks/generic/utilities.yml
@@ -1,6 +1,6 @@
 ---
 - name: Apply role packages
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['packages']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/validate-container-status.yml
+++ b/playbooks/generic/validate-container-status.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run container_status validator
-  hosts: "{{ hosts_container_status|default('all') }}"
+  hosts: "{{ hosts_container_status|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['container_status']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/validate-kernel-version.yml
+++ b/playbooks/generic/validate-kernel-version.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run kernel_version validator
-  hosts: "{{ hosts_kernel_version|default('all') }}"
+  hosts: "{{ hosts_kernel_version|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['kernel_version']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/validate-system-encoding.yml
+++ b/playbooks/generic/validate-system-encoding.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run system_encoding validator
-  hosts: "{{ hosts_system_encoding|default('all') }}"
+  hosts: "{{ hosts_system_encoding|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['system_encoding']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/validate-ulimits.yml
+++ b/playbooks/generic/validate-ulimits.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run ulimits validator
-  hosts: "{{ hosts_ulimits|default('all') }}"
+  hosts: "{{ hosts_ulimits|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['ulimits']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/wait-for-connection.yml
+++ b/playbooks/generic/wait-for-connection.yml
@@ -1,6 +1,6 @@
 ---
 - name: Wait until remote systems are reachable
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   serial: "{{ osism_serial['wait-for-connection']|default('0') }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 

--- a/playbooks/generic/write-facts.yml
+++ b/playbooks/generic/write-facts.yml
@@ -1,7 +1,7 @@
 ---
 - name: Gather facts for all hosts
   ignore_unreachable: true
-  hosts: "{{ hosts_facts|default('all') }}"
+  hosts: "{{ hosts_facts|default(hosts_default_group|default('generic')) }}"
   gather_facts: false
 
   tasks:
@@ -9,7 +9,7 @@
       ansible.builtin.setup:
 
 - name: Write all available facts
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   vars:

--- a/playbooks/infrastructure/netbird.yml
+++ b/playbooks/infrastructure/netbird.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:

--- a/playbooks/monitoring/netdata.yml
+++ b/playbooks/monitoring/netdata.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:

--- a/playbooks/monitoring/remove-netdata.yml
+++ b/playbooks/monitoring/remove-netdata.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -13,7 +13,7 @@
 
 - name: Remove netdata
   hosts:
-    - "{{ hosts_netdata|default('all') }}"
+    - "{{ hosts_netdata|default(hosts_default_group|default('generic')) }}"
     - "&enable_netdata_True"
   serial: "{{ osism_serial['netdata']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/monitoring/remove-zabbix-agent.yml
+++ b/playbooks/monitoring/remove-zabbix-agent.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:
@@ -13,7 +13,7 @@
 
 - name: Remove zabbix_agent
   hosts:
-    - "{{ hosts_zabbix_agent|default('all') }}"
+    - "{{ hosts_zabbix_agent|default(hosts_default_group|default('generic')) }}"
     - "&enable_zabbix_agent_True"
   serial: "{{ osism_serial['zabbix_agent']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"

--- a/playbooks/monitoring/scaphandre.yml
+++ b/playbooks/monitoring/scaphandre.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:

--- a/playbooks/monitoring/thanos_sidecar.yml
+++ b/playbooks/monitoring/thanos_sidecar.yml
@@ -1,6 +1,6 @@
 ---
 - name: Group hosts based on configuration
-  hosts: all
+  hosts: "{{ hosts_default_group|default('generic') }}"
   gather_facts: false
 
   tasks:

--- a/playbooks/state/bootstrap.yml
+++ b/playbooks/state/bootstrap.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set bootstrap state
-  hosts: "{{ hosts_state_status_bootstrap|default('all') }}"
+  hosts: "{{ hosts_state_status_bootstrap|default(hosts_default_group|default('generic')) }}"
   serial: "{{ osism_serial['state']|default(osism_serial_default)|default(0) }}"
   strategy: "{{ osism_strategy|default('linear') }}"
 


### PR DESCRIPTION
close #436 

This pull request addresses #436.

I replaced the "all" group by `default(hosts_default_group|default('generic'))` with a regex replace.
I simply adjusted the defaults in the following way:
```
$ find . -type f -name "*.yml" -exec sed -i "~s,hosts: all,hosts: \"{{ default(hosts_default_group|default('generic')) }}\",g" {} \;
$ find . -type f -name "*.yml" -exec sed -i "~s,|default('all'),|default(hosts_default_group|default('generic')),g" {} \;
```
As I haven't been working on this for very long, it may well take a little more work, but perhaps we can dare to do so :-)