### PR TITLE
Add playbook to check ceph network connectitvity

### DIFF
--- a/playbooks/ceph/ceph-network-connectivity.yml
+++ b/playbooks/ceph/ceph-network-connectivity.yml
@@ -1,0 +1,25 @@
+---
+###
+# This playbook checks the network coonectivity
+# inside a OSISM-deployed Ceph cluster:
+
+- name: Validate network connectivity
+  hosts: ceph
+  strategy: linear
+  gather_facts: true
+
+  tasks:
+    - name: Checking ceph public network for all ceph nodes
+      ansible.builtin.include_role:
+        name: osism.validations.network_connectivity
+      vars:
+        group: "{{  groups['ceph'] }}"
+        network_cidr: "{{ public_network }}"
+    - name: Checking ceph cluster network for ceph OSD nodes
+      ansible.builtin.include_role:
+        name: osism.validations.network_connectivity
+      vars:
+        group: "{{  groups['ceph-osd'] }}"
+        network_cidr: "{{ cluster_network }}"
+      when:
+        - cluster_network | ansible.utils.ipaddr != public_network | ansible.utils.ipaddr

--- a/playbooks/ceph/validate-ceph-connectivity.yml
+++ b/playbooks/ceph/validate-ceph-connectivity.yml
@@ -4,7 +4,7 @@
 # inside a OSISM-deployed Ceph cluster:
 
 - name: Validate network connectivity
-  hosts: ceph
+  hosts: "{{ ceph_group_name | default('ceph') }}"
   strategy: linear
   gather_facts: true
 
@@ -13,13 +13,14 @@
       ansible.builtin.include_role:
         name: osism.validations.network_connectivity
       vars:
-        group: "{{  groups['ceph'] }}"
-        network_cidr: "{{ public_network }}"
-    - name: Checking ceph cluster network for ceph OSD nodes
+        network_connectivity_group: "{{  groups[ceph_group_name | default('ceph')] }}"
+        network_connectivity_network_cidr: "{{ public_network }}"
+
+    - name: Checking ceph cluster network for all ceph OSD nodes
       ansible.builtin.include_role:
         name: osism.validations.network_connectivity
       vars:
-        group: "{{  groups['ceph-osd'] }}"
-        network_cidr: "{{ cluster_network }}"
+        network_connectivity_group: "{{  groups[osd_group_name | default('ceph-osd')] }}"
+        network_connectivity_network_cidr: "{{ cluster_network }}"
       when:
         - cluster_network | ansible.utils.ipaddr != public_network | ansible.utils.ipaddr


### PR DESCRIPTION
Add a playbook to check network connectivity between ceph nodes on `public_network` and for ceph OSD nodes also on
`cluster_network` if it differs.

Part of https://github.com/osism/issues/issues/1088