### PR TITLE
Check connectivity from OpenStack nodes to ceph public network

### DIFF
--- a/playbooks/ceph/validate-ceph-connectivity.yml
+++ b/playbooks/ceph/validate-ceph-connectivity.yml
@@ -4,7 +4,19 @@
 # inside a OSISM-deployed Ceph cluster:
 
 - name: Validate public network connectivity
-  hosts: "{{ ceph_group_name | default('ceph') }}"
+  hosts: "{{ ceph_public_network_group_name_list | default(ceph_public_network_default_group_name_list) }}"
+  vars:
+    ceph_public_network_default_group_name_list:
+      - ceph
+      - cinder-volume
+      - cinder-backup
+      - glance-api
+      - gnocchi-api
+      - gnocchi-metricd
+      - gnocchi-statsd
+      - manila-share
+      - compute
+      - zun-compute
   strategy: linear
   gather_facts: true
 
@@ -13,7 +25,7 @@
       ansible.builtin.include_role:
         name: osism.validations.network_connectivity
       vars:
-        network_connectivity_group: "{{  groups[ceph_group_name | default('ceph')] }}"
+        network_connectivity_group: "{{ ceph_public_network_group_name_list | default(ceph_public_network_default_group_name_list) | map('extract', groups) | list | flatten | unique }}"
         network_connectivity_network_cidr: "{{ public_network }}"
 
 - name: Validate cluster network connectivity


### PR DESCRIPTION
Extend `ceh/validate-ceph-connectivity.yml` playbook to also check
connection from all hosts deployed by `kolla-ansible` which need to
access `ceph` if it is used as their backend.
Unfortunately there seems to be no way to actually only include the
service`s host if `ceph` is enabled as its backend, since the required
variables are loaded as `hostvars` in the generated inventory file.
The `hostvars` are not accessible at play level.
A different implementation using a single play on all hosts leveraging
`delegate_to` and loops over actual hosts was explored, but
`delegate_to` cannot be combined with `include_role`.
Thus this implementation will only cover the standard case of all
services using ceph as a backend. If the deployment differs the
respecting group variables will need to be adapted.

Part of https://github.com/osism/issues/issues/1089