### PR TITLE
Set k3s_kubectl_binary for the k3s server role

### DIFF
--- a/playbooks/infrastructure/k3s.yml
+++ b/playbooks/infrastructure/k3s.yml
@@ -23,6 +23,9 @@
   gather_facts: false
   environment: "{{ k3s_proxy_env | default({}) }}"
 
+  vars:
+    k3s_kubectl_binary: k3s kubectl
+
   roles:
     - name: Apply role k3s_server
       become: true


### PR DESCRIPTION
At the moment of the deployment of the k3s server the kubectl binary is not yet usable.