### PR TITLE
limit gather-facts to a certain group of hosts

### DIFF
--- a/playbooks/generic/facts.yml
+++ b/playbooks/generic/facts.yml
@@ -9,4 +9,6 @@
     - role: osism.commons.facts
 
 - name: Import gather-facts play
-  ansible.builtin.import_playbook: gather-facts.yml
+  hosts: "{{ hosts_facts|default(hosts_default_group|default('all')) }}"
+  tasks:
+    - ansible.builtin.import_playbook: gather-facts.yml


### PR DESCRIPTION
As an addition to use a defined group instead the "all" group, this changes the fact gathering to that group for consistency reasons.