### PR TITLE
rewrite label playbook to allow labels, annotations and taints to be defined on group and host level in inventory

### DIFF
--- a/playbooks/infrastructure/kubernetes-label-nodes.yml
+++ b/playbooks/infrastructure/kubernetes-label-nodes.yml
@@ -4,10 +4,6 @@
   gather_facts: false
 
   vars:
-    k3s_add_labels: []
-    k3s_add_annotations: []
-    k3s_add_taints: []
-
     k3s_add_labels_groups: []
     k3s_add_annotations_groups: []
     k3s_add_taints_groups: []
@@ -15,9 +11,9 @@
   tasks:
     - name: Merge labels, annotations, and taints
       ansible.builtin.set_fact:
-        _k3s_add_labels: "{{ lookup('community.general.merge_variables', '^k3s_add_labels__.+$', initial_value=k3s_add_labels, groups=k3s_add_labels_groups) }}"
-        _k3s_add_annotations: "{{ lookup('community.general.merge_variables', '^k3s_add_annotations__.+$', initial_value=k3s_add_annotations, groups=k3s_add_annotations_groups) }}"
-        _k3s_add_taints: "{{ lookup('community.general.merge_variables', '^k3s_add_taints__.+$', initial_value=k3s_add_taints, groups=k3s_add_taints_groups) }}"
+        _k3s_add_labels: "{{ lookup('community.general.merge_variables', '^k3s_add_labels__.+$', initial_value=k3s_add_labels|default([], true), groups=k3s_add_labels_groups) }}"
+        _k3s_add_annotations: "{{ lookup('community.general.merge_variables', '^k3s_add_annotations__.+$', initial_value=k3s_add_annotations|default([], true), groups=k3s_add_annotations_groups) }}"
+        _k3s_add_taints: "{{ lookup('community.general.merge_variables', '^k3s_add_taints__.+$', initial_value=k3s_add_taints|default([], true), groups=k3s_add_taints_groups) }}"
         cacheable: false
 
     - name: Manage labels

--- a/playbooks/infrastructure/kubernetes-label-nodes.yml
+++ b/playbooks/infrastructure/kubernetes-label-nodes.yml
@@ -7,7 +7,7 @@
     ansible_python_interpreter: /usr/bin/python3
 
   tasks:
-    - name: merge all labels, annotations, and taints
+    - name: Merge all labels, annotations, and taints
       set_fact:
         merged_add_labels: "{{ lookup('community.general.merge_variables', '^k3s_add_labels_.+$') | default([], true) }}"
         merged_add_annotations: "{{ lookup('community.general.merge_variables', '^k3s_add_annotations_.+$') | default([], true) }}"

--- a/playbooks/infrastructure/kubernetes-label-nodes.yml
+++ b/playbooks/infrastructure/kubernetes-label-nodes.yml
@@ -11,9 +11,9 @@
   tasks:
     - name: Merge labels, annotations, and taints
       ansible.builtin.set_fact:
-        _k3s_add_labels: "{{ lookup('community.general.merge_variables', '^k3s_add_labels__.+$', initial_value=k3s_add_labels|default([], true), groups=k3s_add_labels_groups) }}"
-        _k3s_add_annotations: "{{ lookup('community.general.merge_variables', '^k3s_add_annotations__.+$', initial_value=k3s_add_annotations|default([], true), groups=k3s_add_annotations_groups) }}"
-        _k3s_add_taints: "{{ lookup('community.general.merge_variables', '^k3s_add_taints__.+$', initial_value=k3s_add_taints|default([], true), groups=k3s_add_taints_groups) }}"
+        _k3s_add_labels: "{{ lookup('community.general.merge_variables', '^k3s_add_labels__.+$', initial_value=k3s_add_labels | default([], true), groups=k3s_add_labels_groups) }}"
+        _k3s_add_annotations: "{{ lookup('community.general.merge_variables', '^k3s_add_annotations__.+$', initial_value=k3s_add_annotations | default([], true), groups=k3s_add_annotations_groups) }}"
+        _k3s_add_taints: "{{ lookup('community.general.merge_variables', '^k3s_add_taints__.+$', initial_value=k3s_add_taints | default([], true), groups=k3s_add_taints_groups) }}"
         cacheable: false
 
     - name: Manage labels

--- a/playbooks/infrastructure/kubernetes-label-nodes.yml
+++ b/playbooks/infrastructure/kubernetes-label-nodes.yml
@@ -1,98 +1,53 @@
 ---
-- name: Label nodes
-  hosts:
-    - "{{ hosts_manager|default(groups['manager'][0])|default('localhost') }}"
+- name: Add and Remove labels, annotations, and taints from all k3s nodes and masters
+  hosts: k3s_all
   connection: local
   gather_facts: false
-
   vars:
     ansible_python_interpreter: /usr/bin/python3
 
   tasks:
-    - name: Add openstack-control-plane label to all hosts labeled control-plane
+    - name: merge all labels, annotations, and taints
+      set_fact:
+        merged_add_labels: "{{ lookup('community.general.merge_variables', '^k3s_add_labels_.+$') | default([], true) }}"
+        merged_add_annotations: "{{ lookup('community.general.merge_variables', '^k3s_add_annotations_.+$') | default([], true) }}"
+        merged_add_taints: "{{ lookup('community.general.merge_variables', '^k3s_add_taints_.+$') | default([], true) }}"
+
+    - name: Add labels to k3s_node and k3s_master
       ansible.builtin.shell: |
         set -o pipefail
 
         export KUBECONFIG=/share/kubeconfig
-
-        OS_CONTROL_PLANE_NODES=$(kubectl get nodes | grep control-plane | awk '{print $1}')
-        for NODE in $OS_CONTROL_PLANE_NODES; do
-            kubectl label node "${NODE}" openstack-control-plane=enabled
-        done
+        # Add labels
+        kubectl label node {{ inventory_hostname.split('.')[0] }} {{ item }} --overwrite
       args:
         executable: /bin/bash
       changed_when: false
+      delegate_to: manager
+      loop: "{{ merged_add_labels }}"
 
-    - name: Add worker node-role label to all hosts without a role
+    - name: Add annotations to k3s_node and k3s_master
       ansible.builtin.shell: |
         set -o pipefail
 
         export KUBECONFIG=/share/kubeconfig
-
-        NODES_WITHOUT_ROLE=$(kubectl get nodes | grep '<none>' | awk '{print $1}')
-        for NODE in $NODES_WITHOUT_ROLE; do
-            kubectl label node "${NODE}" node-role.kubernetes.io/worker=worker
-        done
+        # Add annotations
+        kubectl annotate node {{ inventory_hostname.split('.')[0] }} {{ item }} --overwrite
       args:
         executable: /bin/bash
       changed_when: false
+      delegate_to: manager
+      loop: "{{ merged_add_annotations }}"
 
-    - name: Add control-plane label to all hosts in group control
+    - name: Add taints to k3s_node and k3s_master
       ansible.builtin.shell: |
         set -o pipefail
 
         export KUBECONFIG=/share/kubeconfig
-        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/control-plane=true
+        # Add taints
+        kubectl taint node {{ inventory_hostname.split('.')[0] }} {{ item }} --overwrite
       args:
         executable: /bin/bash
       changed_when: false
-      loop: "{{ groups[hosts_control | default('control')] }}"
-      when: item in groups['k3s_all']
-
-    - name: Add compute-plane label to all hosts in group compute
-      ansible.builtin.shell: |
-        set -o pipefail
-
-        export KUBECONFIG=/share/kubeconfig
-        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/compute-plane=true
-      args:
-        executable: /bin/bash
-      changed_when: false
-      loop: "{{ groups[hosts_compute | default('compute')] }}"
-      when: item in groups['k3s_all']
-
-    - name: Add network-plane label to all hosts in group network
-      ansible.builtin.shell: |
-        set -o pipefail
-
-        export KUBECONFIG=/share/kubeconfig
-        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/network-plane=true
-      args:
-        executable: /bin/bash
-      changed_when: false
-      loop: "{{ groups[hosts_network | default('network')] }}"
-      when: item in groups['k3s_all']
-
-    - name: Add management-plane label to all hosts in group manager
-      ansible.builtin.shell: |
-        set -o pipefail
-
-        export KUBECONFIG=/share/kubeconfig
-        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/management-plane=true
-      args:
-        executable: /bin/bash
-      changed_when: false
-      loop: "{{ groups[hosts_manager | default('manager')] }}"
-      when: item in groups['k3s_all']
-
-    - name: Add monitoring-plane label to all hosts in group monitoring
-      ansible.builtin.shell: |
-        set -o pipefail
-
-        export KUBECONFIG=/share/kubeconfig
-        kubectl label node "{{ item.split('.')[0] }}" node-role.osism.tech/monitoring-plane=true
-      args:
-        executable: /bin/bash
-      changed_when: false
-      loop: "{{ groups[hosts_monitoring | default('monitoring')] }}"
-      when: item in groups['k3s_all']
+      delegate_to: manager
+      loop: "{{ merged_add_taints }}"

--- a/playbooks/infrastructure/kubernetes-label-nodes.yml
+++ b/playbooks/infrastructure/kubernetes-label-nodes.yml
@@ -1,53 +1,57 @@
 ---
-- name: Add and Remove labels, annotations, and taints from all k3s nodes and masters
-  hosts: k3s_all
-  connection: local
+- name: Manage labels, annotations, and taints on all k3s nodes
+  hosts: "{{ hosts_k3s_all|default('k3s_all') }}"
   gather_facts: false
+
   vars:
-    ansible_python_interpreter: /usr/bin/python3
+    k3s_add_labels: []
+    k3s_add_annotations: []
+    k3s_add_taints: []
+
+    k3s_add_labels_groups: []
+    k3s_add_annotations_groups: []
+    k3s_add_taints_groups: []
 
   tasks:
-    - name: Merge all labels, annotations, and taints
+    - name: Merge labels, annotations, and taints
       ansible.builtin.set_fact:
-        merged_add_labels: "{{ lookup('community.general.merge_variables', '^k3s_add_labels_.+$') | default([], true) }}"
-        merged_add_annotations: "{{ lookup('community.general.merge_variables', '^k3s_add_annotations_.+$') | default([], true) }}"
-        merged_add_taints: "{{ lookup('community.general.merge_variables', '^k3s_add_taints_.+$') | default([], true) }}"
+        _k3s_add_labels: "{{ lookup('community.general.merge_variables', '^k3s_add_labels__.+$', initial_value=k3s_add_labels, groups=k3s_add_labels_groups) }}"
+        _k3s_add_annotations: "{{ lookup('community.general.merge_variables', '^k3s_add_annotations__.+$', initial_value=k3s_add_annotations, groups=k3s_add_annotations_groups) }}"
+        _k3s_add_taints: "{{ lookup('community.general.merge_variables', '^k3s_add_taints__.+$', initial_value=k3s_add_taints, groups=k3s_add_taints_groups) }}"
+        cacheable: false
 
-    - name: Add labels to k3s_node and k3s_master
+    - name: Manage labels
       ansible.builtin.shell: |
         set -o pipefail
 
         export KUBECONFIG=/share/kubeconfig
-        # Add labels
         kubectl label node {{ inventory_hostname.split('.')[0] }} {{ item }} --overwrite
       args:
         executable: /bin/bash
       changed_when: false
-      delegate_to: manager
-      loop: "{{ merged_add_labels }}"
+      loop: "{{ _k3s_add_labels }}"
+      delegate_to: localhost
 
-    - name: Add annotations to k3s_node and k3s_master
+    - name: Manage annotations
       ansible.builtin.shell: |
         set -o pipefail
 
         export KUBECONFIG=/share/kubeconfig
-        # Add annotations
         kubectl annotate node {{ inventory_hostname.split('.')[0] }} {{ item }} --overwrite
       args:
         executable: /bin/bash
       changed_when: false
-      delegate_to: manager
-      loop: "{{ merged_add_annotations }}"
+      loop: "{{ _k3s_add_annotations }}"
+      delegate_to: localhost
 
-    - name: Add taints to k3s_node and k3s_master
+    - name: Manage taints
       ansible.builtin.shell: |
         set -o pipefail
 
         export KUBECONFIG=/share/kubeconfig
-        # Add taints
         kubectl taint node {{ inventory_hostname.split('.')[0] }} {{ item }} --overwrite
       args:
         executable: /bin/bash
       changed_when: false
-      delegate_to: manager
-      loop: "{{ merged_add_taints }}"
+      loop: "{{ _k3s_add_taints }}"
+      delegate_to: localhost

--- a/playbooks/infrastructure/kubernetes-label-nodes.yml
+++ b/playbooks/infrastructure/kubernetes-label-nodes.yml
@@ -8,7 +8,7 @@
 
   tasks:
     - name: Merge all labels, annotations, and taints
-      set_fact:
+      ansible.builtin.set_fact:
         merged_add_labels: "{{ lookup('community.general.merge_variables', '^k3s_add_labels_.+$') | default([], true) }}"
         merged_add_annotations: "{{ lookup('community.general.merge_variables', '^k3s_add_annotations_.+$') | default([], true) }}"
         merged_add_taints: "{{ lookup('community.general.merge_variables', '^k3s_add_taints_.+$') | default([], true) }}"


### PR DESCRIPTION
This changes the label playbook to be reused otherwise to set zone or region labels etc. based on the inventory.

example:
```
k3s_add_labels:
  - topology.kubernetes.io/zone=zone-a
  - topology.kubernetes.io/region=RegionOne

k3s_add_annotations:
  - node.kubernetes.io/instance-type=n1-standard-1

k3s_add_taints:
  - key=value:NoSchedule

```


The previeously set labels should be moved into the default inventory for `k3s_master` and `k3s_node` groups as well as `compute`, `manager`, `control` and `network`.

A PR for that will follow in the respective repository