### PR TITLE
Always fetch keys in ceph-copy-keys when explicitly tagged

### DIFF
--- a/playbooks/manager/copy-ceph-keys.yml
+++ b/playbooks/manager/copy-ceph-keys.yml
@@ -64,7 +64,7 @@
       environment:
         INTERACTIVE: "false"
       changed_when: true
-      when: _fetch_ceph_keys | default(false)
+      when: _fetch_ceph_keys | default(false) or 'fetch' in ansible_run_tags
       tags:
         - fetch
 


### PR DESCRIPTION
Currently using the `fetch` tag for `ceph-copy-keys` results in the task being skipped since the fact used in the `when` condition is unset and defaults to `false`.
Therefore the condition is changed, so that the task is also run when it is explicitly tagged.

Part of https://github.com/osism/issues/issues/1218