### PR TITLE
Remove indiscriminate restart of the manager service

### DIFF
--- a/playbooks/manager/manager.yml
+++ b/playbooks/manager/manager.yml
@@ -4,13 +4,3 @@
 
   roles:
     - role: osism.services.manager
-
-- name: Restart manager service
-  hosts: manager
-
-  tasks:
-    - name: Restart manager service
-      become: true
-      ansible.builtin.service:
-        name: docker-compose@manager
-        state: restarted


### PR DESCRIPTION
Let the manager role restart the manager using the build-in handlers.