### PR TITLE
Add directory existence check before writing Ceph keys

### DIFF
--- a/playbooks/manager/copy-ceph-keys.yml
+++ b/playbooks/manager/copy-ceph-keys.yml
@@ -67,14 +67,24 @@
       loop_control:
         label: "{{ item.item.src }}"
 
+    - name: Check if target directories exist
+      ansible.builtin.stat:
+        path: "{{ item.dest | dirname }}"
+      register: _target_directories
+      loop: "{{ ceph_infrastructure_keys + ceph_kolla_keys + ceph_custom_keys }}"
+      loop_control:
+        label: "{{ item.dest | dirname }}"
+
     - name: Write ceph keys to the configuration directory
       ansible.builtin.copy:
-        content: "{{ item.content | b64decode }}"
-        dest: "{{ item.item.dest }}"
+        content: "{{ item.0.content | b64decode }}"
+        dest: "{{ item.0.item.dest }}"
         owner: dragon
         group: dragon
         mode: 0640
-      when: not item.failed
-      loop: "{{ _remote_ceph_keys.results }}"
+      when:
+        - not item.0.failed
+        - item.1.stat.exists and item.1.stat.isdir
+      loop: "{{ _remote_ceph_keys.results | zip(_target_directories.results) | list }}"
       loop_control:
-        label: "{{ item.item.src }}"
+        label: "{{ item.0.item.src }}"


### PR DESCRIPTION
Ensure target directories exist before attempting to write Ceph keys to the configuration directory. This prevents write failures when target paths don't exist.

AI-assisted: Claude Code