### PR TITLE
Fix validate-ceph-osds crash on stale cached facts

### DIFF
--- a/playbooks/ceph/validate-ceph-osds.yml
+++ b/playbooks/ceph/validate-ceph-osds.yml
@@ -273,6 +273,20 @@
         # just use a fact you just set in the same set_fact task.
         - name: Aggregate test results step one
           ansible.builtin.set_fact:
+            # The test results are per-host facts and the report is
+            # written run_once, i.e. with the first host's values.
+            # A test counts as failed if it failed on any host.
+            _osds_test_containers_count_result:
+              "{{ 'failed'
+                  if 'failed' in
+                  (play_hosts |
+                   map(\
+                       'extract',
+                       hostvars,
+                       '_osds_test_containers_count_result'\
+                      ) | list)
+                  else 'passed'
+               }}"
             _osds_test_containers_count_data:
               "{{
                  play_hosts |
@@ -282,7 +296,17 @@
                      '_osds_test_containers_count_data'\
                     )
                }}"
-
+            _osds_test_containers_running_result:
+              "{{ 'failed'
+                  if 'failed' in
+                  (play_hosts |
+                   map(\
+                       'extract',
+                       hostvars,
+                       '_osds_test_containers_running_result'\
+                      ) | list)
+                  else 'passed'
+               }}"
             _osds_test_containers_running_data:
               "{{
                  play_hosts |
@@ -632,6 +656,20 @@
 
     # END OF TESTS SECTION
 
+    # Tests 4 and 5 set _osds_test_failed per host again, so the
+    # cross-host aggregation has to be repeated before the verdict
+    # below, which is evaluated run_once
+    - name: Aggregate test failed state across hosts
+      ansible.builtin.set_fact:
+        _osds_test_failed:
+          "{{ play_hosts |
+              map('extract', hostvars, '_osds_test_failed') |
+              select |
+              list |
+              length > 0
+           }}"
+      run_once: true
+
     # Set validation result to passed if no test failed
     - name: Set validation result to passed if no test failed
       ansible.builtin.set_fact:
@@ -682,6 +720,22 @@
                  ) |
               unique
             }}"
+        # The results of tests 4 and 5 are per-host facts and the
+        # report is written run_once, i.e. with the first host's
+        # values. A test counts as failed if it failed on any host.
+        # Tests 1 and 2 cannot reach this point in failed state and
+        # the test 3 result is already identical on all hosts.
+        _osds_test_encryption_result:
+          "{{ 'failed'
+              if 'failed' in
+              (play_hosts |
+               map(\
+                   'extract',
+                   hostvars,
+                   '_osds_test_encryption_result'\
+                  ) | list)
+              else 'passed'
+           }}"
         _osds_test_encryption_data:
           "{{
               play_hosts |
@@ -692,6 +746,17 @@
                  ) |
               unique
             }}"
+        _osds_test_crush_location_result:
+          "{{ 'failed'
+              if 'failed' in
+              (play_hosts |
+               map(\
+                   'extract',
+                   hostvars,
+                   '_osds_test_crush_location_result'\
+                  ) | list)
+              else 'passed'
+           }}"
         _osds_test_crush_location_data:
           "{{
               play_hosts |

--- a/playbooks/ceph/validate-ceph-osds.yml
+++ b/playbooks/ceph/validate-ceph-osds.yml
@@ -244,6 +244,22 @@
            List: {{ _osds_containers }}"
       when: _osds_num_containers_not_running | int == 0
 
+    # _osds_test_failed is a per-host fact, but conditionals on
+    # run_once tasks are evaluated on the first host only. Aggregate
+    # the flag across all hosts (set_fact with run_once applies the
+    # result to every host) so that a container test failure on any
+    # host triggers the bail-out below.
+    - name: Aggregate test failed state across hosts
+      ansible.builtin.set_fact:
+        _osds_test_failed:
+          "{{ play_hosts |
+              map('extract', hostvars, '_osds_test_failed') |
+              select |
+              list |
+              length > 0
+           }}"
+      run_once: true
+
     # I bail out early here if one of the two container tests failed
     # as it indicates a major problem and could be problematic
     # when trying to run the other tests. It's simpler to bail

--- a/playbooks/ceph/validate-ceph-osds.yml
+++ b/playbooks/ceph/validate-ceph-osds.yml
@@ -29,6 +29,13 @@
     _osds_reports_directory: "/opt/reports/validator"
 
   tasks:
+    # With gathering = smart, gather_facts is served from the fact
+    # cache, where ansible_local.docker_containers may predate the
+    # OSD deployment. Run setup explicitly to validate against the
+    # live container list instead of a stale cache.
+    - name: Gather fresh facts
+      ansible.builtin.setup:
+
     # ansible_date_time is cached between runs,
     # so we need to get a timestamp another way
     - name: Get timestamp for report file

--- a/playbooks/ceph/validate-ceph-osds.yml
+++ b/playbooks/ceph/validate-ceph-osds.yml
@@ -127,10 +127,14 @@
     # START OF TESTS SECTION
 
     # Test 1: Check number of OSD containers equals calculated number
+    # _osds_containers must be initialized here: the set_fact loop
+    # below never runs when no container matches, leaving the
+    # variable undefined instead of reporting a count of zero
     - name: Prepare test data
       ansible.builtin.set_fact:
         _osds_test_containers_count_result: "no-result"
         _osds_test_containers_count_data: ""
+        _osds_containers: []
 
     - name: Get list of ceph-osd containers on host
       ansible.builtin.set_fact:


### PR DESCRIPTION
## Problem

`osism validate ceph-osds` fails fatally on every OSD host of a freshly
deployed, healthy cluster (`HEALTH_OK`, all OSDs up+in):

```
fatal: [testbed-node-3]: FAILED! => {"msg": "The task includes an option with an
undefined variable.. '_osds_containers' is undefined ..."}
```

Two stacked defects:

1. **Undefined variable on zero matches.** `_osds_containers` is built by a
   `set_fact` loop guarded by `when: item.name is match('/ceph-osd.*')`. When no
   container matches, the task never runs and the variable is never created —
   the `default([])` exists only inside the accumulating expression. The next
   task evaluates `_osds_containers | length` and dies.
2. **The container list comes from a stale fact cache.** The play relies on
   `gather_facts: true`, but the OSISM-generated ansible.cfg uses
   `gathering = smart` with a Redis fact cache (24 h timeout), so gathering is
   served from cache. On a fresh deploy the cache was last written by the facts
   refresh that runs *before* the ceph role — zero `ceph-osd-*` containers in
   `ansible_local.docker_containers`. Until now the only remedy was an
   undocumented `osism apply facts` before the validate.

## Changes

- Initialize `_osds_containers: []` so a host with zero OSD containers produces
  a failed containers-count test ("expected N, found 0") instead of a fatal.
- Add an explicit `setup` task: unlike `gather_facts` under `gathering = smart`,
  it always gathers live, re-executing the local fact script behind
  `ansible_local.docker_containers`, and refreshes the cache as a side effect.
  This also removes the inverse risk of *passing* against cached containers
  that no longer run.
- Aggregate `_osds_test_failed` across hosts before the early bail-out and
  before the final verdict: conditionals on `run_once` tasks are evaluated with
  the first host's variables only, so a failure on a non-first host previously
  skipped the bail-out (and later crashed on the empty list in test 4), or
  produced a "passed" verdict for per-host failures in tests 4/5.
- Aggregate the per-test result fields in both report blocks the same way, so
  a report can no longer state `validator_result: failed` while the failing
  test's own result field says `passed`.

## Validation

- `ansible-lint` passes (production profile).
- Root cause and fix verified on a live testbed cluster: with stale cached
  facts the validate failed on all three OSD hosts; after a real fact refresh
  it passes. The staleness is observable via
  `osism dump facts <node> ansible_local | grep -c ceph-osd` (0) vs
  `osism dump facts --no-cache ...` (>0).

Known pre-existing limitation (out of scope): a host that legitimately expects
zero OSDs (empty `devices`/`ceph_osd_devices`) still fails in tests 4/5, which
index into `_osds_containers[0]` / `_osds_crush_node_data[0]`. This predates
this PR (such hosts crashed at the count task before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)